### PR TITLE
Various stuff for v1.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Arrow keys, hjkl or scrollwheel to navigate (Enter goes right), Escape key to ca
 `a` Rename a file\
 `z` or `Backspace` Toggle hidden files\
 `V` Start selecting by moving\
-`n` Create a new file (touch)\
-`N` Create a new folder (mkdir)\
+`n` Create a new file\
+`N` Create a new folder\
 `?` Toggle file properties window
 
 # Configuration
@@ -80,6 +80,9 @@ You can use "do-not-match" in conjunction with "match":
     "do-not-match": ["*.exe"]
 }
 ```
+Programs in `"programs"` do not expand tildes like `"~/some/file.sh"`. You have to specify an absolute path.\
+If you want to use a shell script in `"programs"`, it has to have a shebang or you need to explicitly invoke the appropriate shell like `"bash /some/file.sh"`\
+Note: Programs will be started in the working directory you're inside in fen
 
 # File previews
 fen does not (yet!) have file previews by default\

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,23 @@
 - Bulk rename
 - Scrollable search history
 - Better scrolling
+- File operations async queue (with undo when applicable)
+- Make file previews async
+- Show ~/ in top bar for /home/$USER
+- Show user@something in top bar
+- Changing owner/group, chmod inside fen
 - Index/Length (maybe even percentage) in the bottom right like in vim/ranger
+- Refactor bar.go into top bar and bottom bar
+- Make draw functions for top bar / bottom bar scriptable with lua
+- Global selection (selection stored in a file under UserCacheDir ?)
+- cd Change directory
+- A sort of "pause" (cross-platform please) after opening a file, configurable, maybe excluding it for certain programs like vim
+- Shortcuts / bookmarks (think the 1,2,3,4 number row idea (maybe Ctrl+\<Number\> for it?)
+- Ctrl+Shift+n, Ctrl+Shift+n search by content, search by path name like telescope
+- Check if [dragon](https://github.com/mwh/dragon) works, maybe just make my own built into fen with some gtk wrapper? (bad idea lol)
+- Show current folder size beside disk size?
+- A sort of --no-unicode option, to print the character codes instead of fancy unicode characters
+
 - System-wide configuration file instructions
 - Make file previews not run every time the terminal is resized?
 - Installation instructions for Windows in the README
@@ -26,3 +42,4 @@
 - Fix invisibility near root dir (easy to see on Android with Termux)
 - Performance: Caching stuff (maybe only re-dirlist for left/right)
 - `H` and `L` controls feel weird because the screen scrolls in a specific way instead of just setting the cursor to the bottom of the screen like the behaviour in vim
+- Optional xdg trash specification? https://specifications.freedesktop.org/trash-spec/trashspec-latest.html

--- a/bar.go
+++ b/bar.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -41,7 +44,18 @@ func (bar *Bar) Draw(screen tcell.Screen) {
 		if user.Uid == "0" {
 			usernameColor = "[red:]"
 		}
-		text = "[::b]" + usernameColor + tview.Escape(user.Username) + " [blue::B]" + FilenameSpecialCharactersHighlighted(tview.Escape(PathWithEndSeparator(filepath.Dir(text))), "[blue::B]") + "[white::b]" + FilenameSpecialCharactersHighlighted(tview.Escape(PathWithoutEndSeparator(filepath.Base(text))), "[white::b]")
+
+
+		pathToShow := filepath.Dir(text)
+		if runtime.GOOS == "linux" {
+			homeDir, err := os.UserHomeDir()
+			if err == nil {
+				if strings.HasPrefix(pathToShow, homeDir) {
+					pathToShow = filepath.Join("~", pathToShow[len(homeDir):])
+				}
+			}
+		}
+		text = "[::b]" + usernameColor + tview.Escape(user.Username) + " [blue::B]" + FilenameInvisibleCharactersAsCodeHighlighted(tview.Escape(PathWithEndSeparator(pathToShow)), "[blue::B]") + "[white::b]" + FilenameInvisibleCharactersAsCodeHighlighted(tview.Escape(PathWithoutEndSeparator(filepath.Base(text))), "[white::b]")
 	}
 
 	noWriteEnabledText := ""

--- a/fen.desktop
+++ b/fen.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=fen
+Comment=Launches the fen file manager
+Icon=utilities-terminal
+Terminal=true
+Exec=fen
+Categories=ConsoleOnly;System;FileTools;FileManager
+MimeType=inode/directory;
+Keywords=File;Manager;Browser;Explorer;Launcher

--- a/fen.go
+++ b/fen.go
@@ -63,11 +63,11 @@ type PreviewWithEntry struct {
 	DoNotMatch []string `json:"do-not-match"`
 }
 
-func (fen *Fen) Init(workingDirectory string) error {
+func (fen *Fen) Init(path string) error {
 	fen.selectingWithV = false
 	fen.fileProperties = NewFileProperties()
 
-	fen.wd = workingDirectory
+	fen.wd = path
 
 	fen.topPane = NewBar(&fen.sel, &fen.sel, &fen.config.NoWrite)
 	fen.topPane.isTopBar = true
@@ -85,6 +85,13 @@ func (fen *Fen) Init(workingDirectory string) error {
 	fen.bottomPane = NewBar(&fen.bottomBarText, &fen.sel, &fen.config.NoWrite)
 
 	wdFiles, err := os.ReadDir(fen.wd)
+	shouldSelectSpecifiedFile := false
+
+	stat, statErr := os.Stat(fen.wd)
+	if statErr == nil && !stat.IsDir() {
+		shouldSelectSpecifiedFile = true
+	}
+
 	// If our working directory doesn't exist, go up a parent until it does
 	for err != nil {
 		if filepath.Dir(fen.wd) == fen.wd {
@@ -99,6 +106,10 @@ func (fen *Fen) Init(workingDirectory string) error {
 		// HACKY: middlePane has to have entries so that GoTop() will work
 		fen.middlePane.SetEntries(fen.wd, fen.config.FoldersNotFirst)
 		fen.GoTop()
+
+		if shouldSelectSpecifiedFile {
+			fen.sel = path
+		}
 	}
 
 	fen.history.AddToHistory(fen.sel)
@@ -155,10 +166,10 @@ func (fen *Fen) UpdatePanes() {
 	fen.leftPane.SetEntries(filepath.Dir(fen.wd), fen.config.FoldersNotFirst)
 	fen.middlePane.SetEntries(fen.wd, fen.config.FoldersNotFirst)
 
-	if fen.wd != filepath.Dir(fen.wd) {
-		fen.leftPane.SetSelectedEntryFromString(filepath.Base(fen.wd))
-	} else {
+	if fen.wd == filepath.Dir(fen.wd) {
 		fen.leftPane.entries = []os.DirEntry{}
+	} else {
+		fen.leftPane.SetSelectedEntryFromString(filepath.Base(fen.wd))
 	}
 
 	fen.middlePane.SetSelectedEntryFromString(filepath.Base(fen.sel))

--- a/fen.go
+++ b/fen.go
@@ -161,15 +161,6 @@ func (fen *Fen) UpdatePanes() {
 		fen.leftPane.entries = []os.DirEntry{}
 	}
 
-	username, groupname, err := FileUserAndGroupName(fen.sel)
-	fileOwners := ""
-	if err == nil {
-		fileOwners = " " + UsernameWithColor(username) + ":" + GroupnameWithColor(groupname)
-	}
-	filePermissions, _ := FilePermissionsString(fen.sel)
-	fileLastModified, _ := FileLastModifiedString(fen.sel)
-	fen.bottomBarText = "[teal:]" + filePermissions + fileOwners + " [default:]" + fileLastModified
-
 	fen.middlePane.SetSelectedEntryFromString(filepath.Base(fen.sel))
 
 	// FIXME: Generic bounds checking across all panes in this function
@@ -182,6 +173,15 @@ func (fen *Fen) UpdatePanes() {
 
 	fen.sel = filepath.Join(fen.wd, fen.middlePane.GetSelectedEntryFromIndex(fen.middlePane.selectedEntry))
 	fen.rightPane.SetEntries(fen.sel, fen.config.FoldersNotFirst)
+
+	username, groupname, err := FileUserAndGroupName(fen.sel)
+	fileOwners := ""
+	if err == nil {
+		fileOwners = " " + UsernameWithColor(username) + ":" + GroupnameWithColor(groupname)
+	}
+	filePermissions, _ := FilePermissionsString(fen.sel)
+	fileLastModified, _ := FileLastModifiedString(fen.sel)
+	fen.bottomBarText = "[teal:]" + filePermissions + fileOwners + " [default:]" + fileLastModified
 
 	// Prevents showing 'empty' a second time in rightPane, if middlePane is already showing 'empty'
 	if len(fen.middlePane.entries) <= 0 {

--- a/filespane.go
+++ b/filespane.go
@@ -262,7 +262,6 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 				textView.Box.SetRect(x, y, w, h)
 				textView.SetBackgroundColor(tcell.ColorDefault)
 				textView.SetTextColor(tcell.ColorDefault)
-				textView.SetTextStyle(tcell.StyleDefault.Dim(true))
 				textView.SetDynamicColors(true)
 
 				cmd.Stdout = tview.ANSIWriter(textView)
@@ -301,19 +300,19 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 			style = style.Dim(true)
 		}
 
+		entrySizeText := ""
+		entrySizePrintedSize := 0
+		if fp.showEntrySizes {
+			var err error
+			entrySizeText, err = EntrySize(entryFullPath, fp.fen.config.DontShowHiddenFiles)
+			if err != nil {
+				entrySizeText = "?"
+			}
+
+			_, entrySizePrintedSize = tview.Print(screen, StyleToStyleTagString(style)+" "+tview.Escape(entrySizeText)+" ", x, y+i, w-1, tview.AlignRight, tcell.ColorDefault)
+		}
+
 		styleStr := StyleToStyleTagString(style)
-		tview.Print(screen, spaceForSelected+styleStr+" "+FilenameSpecialCharactersHighlighted(tview.Escape(entry.Name()), styleStr)+strings.Repeat(" ", w), x, y+i, w-1, tview.AlignLeft, tcell.ColorDefault)
-
-		if !fp.showEntrySizes {
-			continue
-		}
-
-		entrySizeText, err := EntrySize(entryFullPath, fp.fen.config.DontShowHiddenFiles)
-		if err != nil {
-			entrySizeText = "?"
-		}
-
-		tview.Print(screen, StyleToStyleTagString(style)+" "+tview.Escape(entrySizeText)+" ", x, y+i, w-1, tview.AlignRight, tcell.ColorDefault)
+		tview.Print(screen, spaceForSelected+styleStr+" "+FilenameInvisibleCharactersAsCodeHighlighted(tview.Escape(entry.Name()), styleStr)+strings.Repeat(" ", w), x, y+i, w-1-entrySizePrintedSize, tview.AlignLeft, tcell.ColorDefault)
 	}
-
 }

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 	dirCopy "github.com/otiai10/copy"
 )
 
-const version = "v1.1.3"
+const version = "v1.1.4"
 
 func main() {
 	userConfigDir, err := os.UserConfigDir()

--- a/main.go
+++ b/main.go
@@ -62,10 +62,10 @@ func main() {
 		os.Exit(0)
 	}
 
-	workingDirectory, err := filepath.Abs(getopt.CommandLine.Arg(0))
+	path, err := filepath.Abs(getopt.CommandLine.Arg(0))
 
-	if workingDirectory == "" || err != nil {
-		workingDirectory, err = os.Getwd()
+	if path == "" || err != nil {
+		path, err = os.Getwd()
 
 		// os.Getwd() will error if the working directory doesn't exist
 		if err != nil {
@@ -74,8 +74,8 @@ func main() {
 				log.Fatalf("Unable to determine current working directory")
 			}
 
-			workingDirectory = os.Getenv("PWD")
-			if workingDirectory == "" {
+			path = os.Getenv("PWD")
+			if path == "" {
 				log.Fatalf("PWD environment variable empty")
 			}
 		}
@@ -98,7 +98,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = fen.Init(workingDirectory)
+	err = fen.Init(path)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -411,7 +411,7 @@ func main() {
 						if event.Rune() == 'n' {
 							os.Create(filepath.Join(fen.wd, inputField.GetText()))
 						} else if event.Rune() == 'N' {
-							os.Mkdir(filepath.Join(fen.wd, inputField.GetText()), 0755)
+							os.Mkdir(filepath.Join(fen.wd, inputField.GetText()), 0775)
 						}
 						fen.UpdatePanes()
 					}

--- a/main.go
+++ b/main.go
@@ -570,7 +570,7 @@ func main() {
 				fileToDelete = fen.sel
 				// When the text wraps, color styling gets reset on line breaks. I have not found a good solution yet
 				styleStr := StyleToStyleTagString(FileColor(fileToDelete))
-				modal.SetText("[red::d]Delete[-:-:-:-] " + styleStr + FilenameSpecialCharactersHighlighted(tview.Escape(filepath.Base(fileToDelete)), styleStr) + "[-:-:-:-] ?")
+				modal.SetText("[red::d]Delete[-:-:-:-] " + styleStr + FilenameInvisibleCharactersAsCodeHighlighted(tview.Escape(filepath.Base(fileToDelete)), styleStr) + "[-:-:-:-] ?")
 			} else {
 				modal.SetText("[red::d]Delete[-:-:-:-] " + tview.Escape(strconv.Itoa(len(fen.selected))) + " selected files?")
 			}

--- a/util.go
+++ b/util.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -441,5 +442,15 @@ func FilePathUniqueNameIfAlreadyExists(path string) string {
 }
 
 func FilenameSpecialCharactersHighlighted(filename, defaultStyle string) string {
-	return strings.ReplaceAll(filename, "\n", "[:red]\\n[-:-:-:-]"+defaultStyle)
+	var ret strings.Builder
+	for _, c := range filename {
+		if !unicode.IsPrint(c) {
+			fmt.Fprintf(&ret, "[:red]%#U[-:-:-:-]"+defaultStyle, c)
+			continue
+		}
+
+		ret.WriteRune(c)
+	}
+	return ret.String()
+	//return strings.ReplaceAll(filename, "\n", "[:red]\\n[-:-:-:-]"+defaultStyle)
 }

--- a/util.go
+++ b/util.go
@@ -387,6 +387,7 @@ func OpenFile(fen *Fen, app *tview.Application, openWith string) {
 			} else {
 				cmd = exec.Command(programName, append(programArguments, fen.selected...)...)
 			}
+			cmd.Dir = fen.wd
 			cmd.Stdin = os.Stdin
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
@@ -441,16 +442,90 @@ func FilePathUniqueNameIfAlreadyExists(path string) string {
 	}
 }
 
-func FilenameSpecialCharactersHighlighted(filename, defaultStyle string) string {
-	var ret strings.Builder
+// Invisible or blank runes like space
+// From https://github.com/flopp/invisible-characters/blob/main/main.go#L63 (Downloaded 2024-06-11 16:52 norway time, commit 0f7fc8a)
+var invisibleRunes = [...]uint64{9, 10, 11, 12, 13, 32, 127, 160, 173, 847, 1564, 4447, 4448, 6068, 6069, 6155, 6156, 6157, 6158, 7355, 7356, 8192, 8193, 8194, 8195, 8196, 8197, 8198, 8199, 8200, 8201, 8202, 8203, 8204, 8205, 8206, 8207, 8234, 8235, 8236, 8237, 8238, 8239, 8287, 8288, 8289, 8290, 8291, 8292, 8293, 8294, 8295, 8296, 8297, 8298, 8299, 8300, 8301, 8302, 8303, 10240, 12288, 12644, 65024, 65025, 65026, 65027, 65028, 65029, 65030, 65031, 65032, 65033, 65034, 65035, 65036, 65037, 65038, 65039, 65279, 65440, 65520, 65521, 65522, 65523, 65524, 65525, 65526, 65527, 65528, 65532, 78844, 119155, 119156, 119157, 119158, 119159, 119160, 119161, 119162, 917504, 917505, 917506, 917507, 917508, 917509, 917510, 917511, 917512, 917513, 917514, 917515, 917516, 917517, 917518, 917519, 917520, 917521, 917522, 917523, 917524, 917525, 917526, 917527, 917528, 917529, 917530, 917531, 917532, 917533, 917534, 917535, 917536, 917537, 917538, 917539, 917540, 917541, 917542, 917543, 917544, 917545, 917546, 917547, 917548, 917549, 917550, 917551, 917552, 917553, 917554, 917555, 917556, 917557, 917558, 917559, 917560, 917561, 917562, 917563, 917564, 917565, 917566, 917567, 917568, 917569, 917570, 917571, 917572, 917573, 917574, 917575, 917576, 917577, 917578, 917579, 917580, 917581, 917582, 917583, 917584, 917585, 917586, 917587, 917588, 917589, 917590, 917591, 917592, 917593, 917594, 917595, 917596, 917597, 917598, 917599, 917600, 917601, 917602, 917603, 917604, 917605, 917606, 917607, 917608, 917609, 917610, 917611, 917612, 917613, 917614, 917615, 917616, 917617, 917618, 917619, 917620, 917621, 917622, 917623, 917624, 917625, 917626, 917627, 917628, 917629, 917630, 917631, 917760, 917761, 917762, 917763, 917764, 917765, 917766, 917767, 917768, 917769, 917770, 917771, 917772, 917773, 917774, 917775, 917776, 917777, 917778, 917779, 917780, 917781, 917782, 917783, 917784, 917785, 917786, 917787, 917788, 917789, 917790, 917791, 917792, 917793, 917794, 917795, 917796, 917797, 917798, 917799, 917800, 917801, 917802, 917803, 917804, 917805, 917806, 917807, 917808, 917809, 917810, 917811, 917812, 917813, 917814, 917815, 917816, 917817, 917818, 917819, 917820, 917821, 917822, 917823, 917824, 917825, 917826, 917827, 917828, 917829, 917830, 917831, 917832, 917833, 917834, 917835, 917836, 917837, 917838, 917839, 917840, 917841, 917842, 917843, 917844, 917845, 917846, 917847, 917848, 917849, 917850, 917851, 917852, 917853, 917854, 917855, 917856, 917857, 917858, 917859, 917860, 917861, 917862, 917863, 917864, 917865, 917866, 917867, 917868, 917869, 917870, 917871, 917872, 917873, 917874, 917875, 917876, 917877, 917878, 917879, 917880, 917881, 917882, 917883, 917884, 917885, 917886, 917887, 917888, 917889, 917890, 917891, 917892, 917893, 917894, 917895, 917896, 917897, 917898, 917899, 917900, 917901, 917902, 917903, 917904, 917905, 917906, 917907, 917908, 917909, 917910, 917911, 917912, 917913, 917914, 917915, 917916, 917917, 917918, 917919, 917920, 917921, 917922, 917923, 917924, 917925, 917926, 917927, 917928, 917929, 917930, 917931, 917932, 917933, 917934, 917935, 917936, 917937, 917938, 917939, 917940, 917941, 917942, 917943, 917944, 917945, 917946, 917947, 917948, 917949, 917950, 917951, 917952, 917953, 917954, 917955, 917956, 917957, 917958, 917959, 917960, 917961, 917962, 917963, 917964, 917965, 917966, 917967, 917968, 917969, 917970, 917971, 917972, 917973, 917974, 917975, 917976, 917977, 917978, 917979, 917980, 917981, 917982, 917983, 917984, 917985, 917986, 917987, 917988, 917989, 917990, 917991, 917992, 917993, 917994, 917995, 917996, 917997, 917998, 917999}
+
+func isInvisible(c rune) bool {
+	if !unicode.IsPrint(c) {
+		return true
+	}
+
+	for _, invisible := range invisibleRunes {
+		if c == rune(invisible) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func RuneToPrintableCode(c rune) string {
+	switch c {
+	case '\a':
+		return "\\a"
+	case '\b':
+		return "\\b"
+	case '\f':
+		return "\\f"
+	case '\n':
+		return "\\n"
+	case '\r':
+		return "\\r"
+	case '\t':
+		return "\\t"
+	case '\v':
+		return "\\v"
+	}
+
+	return "\\u" + strconv.FormatInt(int64(int32(c)), 16)
+}
+
+// Shows invisible runes as escape sequences like "\n", "\r", "\t", or "\u<NUMBER>"
+//
+// Each of these will have a dark-red background, starting with "[:darkred]", and ending with "[-:-:-:-]"+defaultStyle set the colors back to whatever is specified in the defaultStyle style tag string
+//
+// Spaces are shown as normal, except leading and trailing ones, which will be shown as "\u20"
+func FilenameInvisibleCharactersAsCodeHighlighted(filename, defaultStyle string) string {
+	if filename == "" {
+		panic("FilenameSpecialCharactersHighlighted got empty filename")
+	}
+
+	leadingInvisibleOrNonPrintableCharLength := 0
 	for _, c := range filename {
-		if !unicode.IsPrint(c) {
-			fmt.Fprintf(&ret, "[:red]%#U[-:-:-:-]"+defaultStyle, c)
+		if isInvisible(c) {
+			leadingInvisibleOrNonPrintableCharLength++
+		} else {
+			break
+		}
+	}
+
+	trailingInvisibleOrNonPrintableCharLength := 0
+	filenameRunes := []rune(filename)
+	for i := len(filenameRunes) - 1; i >= 0; i-- {
+		c := filenameRunes[i]
+		if isInvisible(c) {
+			trailingInvisibleOrNonPrintableCharLength++
+		} else {
+			break
+		}
+	}
+
+	var ret strings.Builder
+	for i, c := range filename {
+		// Use printable codes for leading and trailing invisible or non-printable runes
+		if i < leadingInvisibleOrNonPrintableCharLength || len(filename) - i <= trailingInvisibleOrNonPrintableCharLength {
+			ret.WriteString("[:darkred]"+RuneToPrintableCode(c)+"[-:-:-:-]"+defaultStyle)
+			continue
+		}
+
+		// For the rest, don't use printable codes for space
+		if c != ' ' && isInvisible(c) {
+			ret.WriteString("[:darkred]"+RuneToPrintableCode(c)+"[-:-:-:-]"+defaultStyle)
 			continue
 		}
 
 		ret.WriteRune(c)
 	}
 	return ret.String()
-	//return strings.ReplaceAll(filename, "\n", "[:red]\\n[-:-:-:-]"+defaultStyle)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -64,3 +64,21 @@ func TestStyleToStyleTagString(t *testing.T) {
 		}
 	}
 }
+
+func TestFilenameInvisibleCharactersAsCodeHighlighted(t *testing.T) {
+	expectedResults := map[[2]string]string{
+		{"file.txt", ""}: "file.txt",
+		{"file.txt", "[blue::b]"}: "file.txt",
+		{"file\n.txt", "[blue::b]"}: "file[:darkred]\\n[-:-:-:-][blue::b].txt",
+		{" a a ", ""}: "[:darkred]\\u20[-:-:-:-]a a[:darkred]\\u20[-:-:-:-]",
+		{"●", ""}: "●",
+		{"\u2800", ""}: "[:darkred]\\u2800[-:-:-:-]",
+	}
+
+	for input, expected := range expectedResults {
+		got := FilenameInvisibleCharactersAsCodeHighlighted(input[0], input[1])
+		if got != expected {
+			t.Fatalf("Expected " + expected + ", but got " + got)
+		}
+	}
+}


### PR DESCRIPTION
- Specifying a file as a command-line argument now selects the file instead of defaulting to the first one in the list
- New folders now use octal 775 permissions instead of 755, like mkdir does
- Fixed bug where the bottom pane file permissions etc. wouldn't show up when starting inside an empty folder
- Show `~/` for the home folder on Linux
- File previews that are not Lua scripts no longer have a dim color
- Show invisible unicode characters and leading/trailing spaces in filenames as dark-red highlighted escape sequences like `\u2800`, `\n`, `\u20`
- Programs started with Ctrl+Space / Ctrl+n now use the selected working directory inside fen, so programs like `unzip` work as expected
- Added a fen.desktop file that opens `fen`