### PR TITLE
Release v1.7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 `!` Run system shell command (cmd on Windows)\
 `Home` or `g` to go to the top\
 `End` or `G` to go to the bottom\
-`Ctrl + Left arrow` to go to the root folder\
-`Ctrl + Right arrow` to go to the path furthest down in history\
+`Ctrl + Left arrow` to go to the root folder (or current Git repository if `fen.git_status=true`)\
+`Ctrl + Right arrow` to go to the path furthest down in history (or first changed file if `fen.git_status=true`)\
 `M` Go to the middle\
 `Page Up` / `Page Down` Scroll up/down an entire page\
 `H` Go to the top of the screen\

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 `c` Goto path\
 `Space` Select files\
 `A` Flip selection in folder (select all files)\
-`D` Deselect all, and un-yank\
+`D` Deselect all, press again to un-yank\
 `a` Rename a file\
 `V` Start selecting by moving\
 `n` Create a new file\

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,19 @@
 - A sort of "back arrow" key for going to the last folder we were in
 - Right pane disappearing when no preview/folder
 
+- Abstract away this common pattern:
+```go
+rel, err := filepath.Rel(basePath, path)
+if err != nil {
+	return
+}
+
+// If it would end up going to the left, return
+if strings.HasPrefix(rel, "..") {
+	return
+}
+```
+
 - Ctrl+Right arrow goes to end of history
 - File list mode ("flattened mode", "flattened folder view" ?)
   - Recursive directory iterator in separate thread updating the entries

--- a/config.lua
+++ b/config.lua
@@ -15,6 +15,7 @@ fen.file_event_interval_ms = 300 -- How often to update the screen on file event
 fen.always_show_info_numbers = false -- Shows the blue, green and yellow numbers in the bottom right even when they are 0
 fen.scroll_speed = 2 -- When scrolling faster than 30ms per scroll, scroll this many entries
 fen.git_status = false -- EXPERIMENTAL: When true, unstaged/untracked files in local git repositories are shown in red
+fen.preview_safety_blocklist = true -- Prevents common sensitive file types from being previewed
 
 -- Everything below this line is non-default examples
 

--- a/fen.go
+++ b/fen.go
@@ -73,17 +73,8 @@ type Config struct {
 	ScrollSpeed             int                  `lua:"scroll_speed"`
 	Bookmarks               [10]string           `lua:"bookmarks"`
 	GitStatus               bool                 `lua:"git_status"`
+	PreviewSafetyBlocklist  bool                 `lua:"preview_safety_blocklist"`
 }
-
-const (
-	SORT_NONE           = "none"
-	SORT_ALPHABETICAL   = "alphabetical"
-	SORT_MODIFIED       = "modified"
-	SORT_SIZE           = "size"
-	SORT_FILE_EXTENSION = "file-extension"
-)
-
-var ValidSortByValues = [...]string{SORT_NONE, SORT_ALPHABETICAL, SORT_MODIFIED, SORT_SIZE, SORT_FILE_EXTENSION}
 
 func NewConfigDefaultValues() Config {
 	// Anything not specified here will have the default value for its type, e.g. false for booleans
@@ -96,7 +87,67 @@ func NewConfigDefaultValues() Config {
 		SortBy:                  SORT_ALPHABETICAL,
 		FileEventIntervalMillis: 300,
 		ScrollSpeed:             2,
+		PreviewSafetyBlocklist:  true,
 	}
+}
+
+const (
+	SORT_NONE           = "none"
+	SORT_ALPHABETICAL   = "alphabetical"
+	SORT_MODIFIED       = "modified"
+	SORT_SIZE           = "size"
+	SORT_FILE_EXTENSION = "file-extension"
+)
+
+var ValidSortByValues = [...]string{SORT_NONE, SORT_ALPHABETICAL, SORT_MODIFIED, SORT_SIZE, SORT_FILE_EXTENSION}
+
+// To prevent previewing sensitive files
+var DefaultPreviewBlocklistCaseInsensitive = []string{
+	// Filezilla passwords
+	"sitemanager.xml",
+	"filezilla.xml",
+
+	// Other
+	".gitconfig",
+	".bash_history",
+	".python_history",
+
+	// Tokens
+	".env",
+
+	// Possible private keys
+	"*.key",
+
+	".Xauthority",
+
+	"*.p12",
+	"*.pfx",
+	"*.pkcs12",
+	"*.pri",
+	"*.cer",
+	"*.der",
+	"*.pem",
+	"*.p7a",
+	"*.p7b",
+	"*.p7c",
+	"*.p7r",
+	"*.spc",
+	"*.p8",
+
+	// Reaper license key
+	"*.rk",
+
+	// Databases
+	"*.db",
+	"*.accdb",
+	"*.mdb",
+	"*.mdf",
+	"*.sqlite*",
+
+	"*.bak",
+
+	// Dataset
+	"*.parquet",
 }
 
 type PreviewOrOpenEntry struct {

--- a/fen.go
+++ b/fen.go
@@ -851,7 +851,7 @@ func (fen *Fen) GoPath(path string) (string, error) {
 func (fen *Fen) GoRootPath() {
 	var path string
 	if runtime.GOOS == "windows" {
-		path = filepath.VolumeName(fen.sel)
+		path = filepath.VolumeName(fen.sel) + string(os.PathSeparator)
 	} else {
 		path = "/"
 	}

--- a/filespane.go
+++ b/filespane.go
@@ -590,6 +590,7 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 				L.SetGlobal("fen", luar.New(L, fenLuaGlobal))
 				err := L.DoFile(previewWith.Script)
 				if err != nil {
+					fp.Box.DrawForSubclass(screen, fp)
 					tview.Print(screen, "File preview Lua error:", x, y, w, tview.AlignLeft, tcell.ColorRed)
 					lines := tview.WordWrap(err.Error(), w)
 					for i, line := range lines {

--- a/filespane.go
+++ b/filespane.go
@@ -360,9 +360,6 @@ func (fp *FilesPane) FilterAndSortEntries() {
 
 			return 1
 		})
-		if fp.fen.config.SortReverse {
-			slices.Reverse(fp.entries.Load().([]os.DirEntry))
-		}
 	case SORT_SIZE:
 		slices.SortStableFunc(fp.entries.Load().([]os.DirEntry), func(a, b fs.DirEntry) int {
 			aInfo, aErr := a.Info()
@@ -391,9 +388,6 @@ func (fp *FilesPane) FilterAndSortEntries() {
 			}
 			return 1
 		})
-		if fp.fen.config.SortReverse {
-			slices.Reverse(fp.entries.Load().([]os.DirEntry))
-		}
 	case SORT_FILE_EXTENSION:
 		// Also sorts folders based on file extension, kind of weird
 		slices.SortStableFunc(fp.entries.Load().([]os.DirEntry), func(a, b fs.DirEntry) int {
@@ -411,11 +405,14 @@ func (fp *FilesPane) FilterAndSortEntries() {
 			return 1
 		})
 	case SORT_NONE: // Does nothing, this has the side effect of making file events always show up at the bottom, until the entire folder is re-read
-	// TODO: Implement filename alphabetical sorting as the default
 	default:
 		fmt.Fprintln(os.Stderr, "Invalid sort_by value \""+fp.fen.config.SortBy+"\"")
 		fmt.Fprintln(os.Stderr, "Valid values: "+strings.Join(ValidSortByValues[:], ", "))
 		os.Exit(1)
+	}
+
+	if fp.fen.config.SortBy != SORT_NONE && fp.fen.config.SortReverse {
+		slices.Reverse(fp.entries.Load().([]os.DirEntry))
 	}
 
 	if fp.fen.config.FoldersFirst {

--- a/filespane.go
+++ b/filespane.go
@@ -627,7 +627,7 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 		return
 	}
 
-	gitRepoContainingPath, repoErr := fp.fen.gitStatusHandler.TrackedGitRepositoryContainingPath(fp.folder)
+	gitRepoContainingPath, repoErr := fp.fen.gitStatusHandler.TryFindTrackedParentGitRepository(fp.folder)
 
 	scrollOffset := fp.GetTopScreenEntryIndex()
 	for i, entry := range fp.entries.Load().([]os.DirEntry)[scrollOffset:] {

--- a/gitstatushandler.go
+++ b/gitstatushandler.go
@@ -33,7 +33,7 @@ type ChangedFileState struct {
 }
 
 // Returns an error if path is not inside a tracked local git repository
-func (gsh *GitStatusHandler) TrackedGitRepositoryContainingPath(path string) (string, error) {
+func (gsh *GitStatusHandler) TryFindTrackedParentGitRepository(path string) (string, error) {
 	gsh.trackedLocalGitReposMutex.Lock()
 	defer gsh.trackedLocalGitReposMutex.Unlock()
 
@@ -53,13 +53,13 @@ func (gsh *GitStatusHandler) TrackedGitRepositoryContainingPath(path string) (st
 }
 
 // Looks for the first parent directory of path (or path itself) containing a ".git" directory.
-// Returns an empty string ("") if none found.
-func (gsh *GitStatusHandler) TryFindContainingGitRepositoryForPath(path string) string {
+// Returns an error if none found.
+func (gsh *GitStatusHandler) TryFindParentGitRepository(path string) (string, error) {
 	repoPathFound := path
 	for {
 		// Reached root path, no git repository found
 		if repoPathFound == filepath.Dir(repoPathFound) {
-			return ""
+			return "", errors.New("path is not in a local Git repository")
 		}
 
 		stat, err := os.Lstat(filepath.Join(repoPathFound, ".git"))
@@ -70,7 +70,7 @@ func (gsh *GitStatusHandler) TryFindContainingGitRepositoryForPath(path string) 
 		repoPathFound = filepath.Dir(repoPathFound)
 	}
 
-	return repoPathFound
+	return repoPathFound, nil
 }
 
 // Returns true if path is an unstaged/untracked file in the local Git repository at repositoryPath.
@@ -158,8 +158,8 @@ func (gsh *GitStatusHandler) Init() {
 				panic("GitStatusHandler received a non-absolute path: \"" + path + "\"")
 			}
 
-			repoPathFound := gsh.TryFindContainingGitRepositoryForPath(path)
-			if repoPathFound == "" {
+			repoPathFound, err := gsh.TryFindParentGitRepository(path)
+			if err != nil {
 				continue chanLoop
 			}
 

--- a/helpscreen.go
+++ b/helpscreen.go
@@ -56,7 +56,7 @@ var helpScreenControlsList = []control{
 	{KeyBindings: []string{"Space"}, Description: "Select files"},
 	{KeyBindings: []string{"A"}, Description: "Flip selection in folder (select all files)"},
 	{KeyBindings: []string{"V"}, Description: "Start selecting by moving"},
-	{KeyBindings: []string{"D"}, Description: "Deselect all, and un-yank"},
+	{KeyBindings: []string{"D"}, Description: "Deselect all, press again to un-yank"},
 	{KeyBindings: []string{"F5"}, Description: "Sync the screen"},
 	{KeyBindings: []string{"0-9"}, Description: "Go to a configured bookmark"},
 }

--- a/history.go
+++ b/history.go
@@ -48,6 +48,8 @@ func (h *History) GetHistoryEntryForPath(path string, hiddenFiles bool) (string,
 				drivePath := filepath.VolumeName(path) + string(os.PathSeparator)
 				if path == drivePath {
 					e = e[len(drivePath):]
+				} else {
+					e = e[len(path)+1:]
 				}
 			} else {
 				if len(path) == 1 {

--- a/history.go
+++ b/history.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -43,10 +44,17 @@ func (h *History) GetHistoryEntryForPath(path string, hiddenFiles bool) (string,
 				continue
 			}
 
-			if len(path) == 1 {
-				e = e[1:]
+			if runtime.GOOS == "windows" {
+				drivePath := filepath.VolumeName(path) + string(os.PathSeparator)
+				if path == drivePath {
+					e = e[len(drivePath):]
+				}
 			} else {
-				e = e[len(path)+1:]
+				if len(path) == 1 {
+					e = e[1:]
+				} else {
+					e = e[len(path)+1:]
+				}
 			}
 			nextSlashIdx := strings.Index(e, string(os.PathSeparator))
 			if nextSlashIdx == -1 {

--- a/lua-file-preview-examples/desktop.lua
+++ b/lua-file-preview-examples/desktop.lua
@@ -1,5 +1,6 @@
 --[[
 -- Works for fen v1.1.2 or above
+-- File preview script for *.desktop files
 --]]
 
 -- https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

--- a/lua-file-preview-examples/go.mod.lua
+++ b/lua-file-preview-examples/go.mod.lua
@@ -1,0 +1,61 @@
+--[[
+-- File preview for go.mod files in Golang projects
+--]]
+--
+local function trimLeftAndRightSpaces(s)
+   return (s:gsub("^%s*(.-)%s*$", "%1"))
+end
+
+local y = 0
+local indirect = "// indirect"
+
+local module = "module"
+local go = "go"
+local replace = "replace"
+local require = "require"
+
+local replacedDependencies = {}
+
+for line in io.lines(fen.SelectedFile) do
+	local style = ""
+
+	if line:sub(1,2) == "//" then
+		style = "[blue::d]"
+	elseif line:sub(1, #replace) == replace then
+		local separator = line:find("=>")
+		if separator ~= nil then
+			local replacing = line:sub(#replace+2, separator - 1)
+			local replacingWith = line:sub(separator + 2)
+			fen:PrintSimple("[yellow]replace [red]"..replacing.."[yellow]=>[default]"..replacingWith, 0, y)
+
+			replacedDependencies[trimLeftAndRightSpaces(replacing)] = true
+			goto continueLine
+		end
+
+		style = "[yellow]"
+	elseif line:sub(-#indirect) == indirect then
+		style = "[gray::d]"
+	elseif line:sub(1, #module) == module then
+		style = "[lime]"
+	elseif line:sub(1, #go) == go then
+		style = "[blue]"
+	elseif line:sub(1, #require) == require then
+		style = "[yellow]"
+	elseif line == ")" then
+		style = "[yellow]"
+	else
+		local words = {}
+		for word in line:gmatch("%S+") do table.insert(words, word) end
+		if replacedDependencies[words[#words-1]] ~= nil then
+			style = "[red]"
+		end
+	end
+
+	fen:PrintSimple(style..fen:Escape(line), 0, y)
+
+	::continueLine::
+	y = y + 1
+	if y >= fen.Height then
+		break
+	end
+end

--- a/lua-file-preview-examples/markdown.lua
+++ b/lua-file-preview-examples/markdown.lua
@@ -65,6 +65,13 @@ for line in io.lines(fen.SelectedFile) do
 	end
 
 	for i = 1, #line do
+		-- Remove single trailing backslash if present
+		if i == #line then
+			if line:sub(i,i) == '\\' then
+				goto continue
+			end
+		end
+
 		char = line:sub(i,i)
 
 		if not codeblock then

--- a/lua-file-preview-examples/markdown.lua
+++ b/lua-file-preview-examples/markdown.lua
@@ -14,6 +14,17 @@ local function isEmphasis(char)
 	return char == '*' or char == '_'
 end
 
+local punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+local punctuationTable = {}
+for i = 1, #punctuation do
+	punctuationTable[punctuation:sub(i,i)] = true
+end
+
+-- https://spec.commonmark.org/0.31.2/#backslash-escapes
+local function isPunctuation(char)
+	return punctuationTable[char] ~= nil
+end
+
 -- https://spec.commonmark.org/0.31.2/#code-fence
 local function isCodeFence(char)
 	return char == '`' or char == '~'
@@ -64,6 +75,7 @@ for line in io.lines(fen.SelectedFile) do
 		end
 	end
 
+	local lineLength = 0
 	for i = 1, #line do
 		-- Remove single trailing backslash if present
 		if i == #line then
@@ -73,8 +85,18 @@ for line in io.lines(fen.SelectedFile) do
 		end
 
 		char = line:sub(i,i)
+		local peekChar = line:sub(i+1,i+1)
+		if i == #line - 1 then
+			peekChar = ""
+		end
 
 		if not codeblock then
+			if isPunctuation(peekChar) and char == '\\' then
+				xOffset = xOffset - 1
+				lastChar = char
+				goto continue
+			end
+
 			if char == '`' and lastChar ~= '`' then
 				backtickString = not backtickString
 				-- It messes up table alignment if we skip over the backticks, so we just replace them with blank space instead
@@ -126,9 +148,22 @@ for line in io.lines(fen.SelectedFile) do
 			style = ""
 		end
 
-		fen:PrintSimple(style..char, i+xOffset-1, y)
+		if char == '\t' then
+			fen:PrintSimple(style.."    ", i+xOffset-1, y)
+			xOffset = xOffset + 3
+		else
+			fen:PrintSimple(style..char, i+xOffset-1, y)
+		end
+
+		lineLength = i
 		lastChar = char
 	    ::continue::
+	end
+
+	if codeblock then
+		for i = 0, fen.Width - lineLength - xOffset do
+			fen:PrintSimple("[:black] ", lineLength+i+xOffset, y)
+		end
 	end
 
 	if lineTrimLeftSpaces:sub(1,1) == "-" then

--- a/lua-file-preview-examples/markdown.lua
+++ b/lua-file-preview-examples/markdown.lua
@@ -1,5 +1,6 @@
 --[[
 -- Works for fen v1.1.3 or above
+-- File preview script for *.md files
 --]]
 
 local function trimLeftSpaces(s)

--- a/lua-file-preview-examples/toml.lua
+++ b/lua-file-preview-examples/toml.lua
@@ -1,3 +1,7 @@
+--[[
+-- File preview script for *.toml files
+--]]
+
 -- Only works with ASCII range characters, UTF-8 stuff like æøå will not be shown correctly unfortunately
 -- It's written pretty naively, some strings might be colored incorrectly
 

--- a/main.go
+++ b/main.go
@@ -566,10 +566,12 @@ func main() {
 			fen.DisableSelectingWithV()
 			return nil
 		} else if event.Rune() == 'D' {
-			if len(fen.selected) > 0 || len(fen.yankSelected) > 0 {
+			if len(fen.selected) > 0 {
 				fen.selected = make(map[string]bool)
+				fen.bottomBar.TemporarilyShowTextInstead("Deselected!")
+			} else if len(fen.yankSelected) > 0 {
 				fen.yankSelected = make(map[string]bool)
-				fen.bottomBar.TemporarilyShowTextInstead("Deselected and un-yanked!")
+				fen.bottomBar.TemporarilyShowTextInstead("Un-yanked!")
 			}
 
 			fen.DisableSelectingWithV()

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func main() {
 				continue
 			}
 
-			_, err = os.Stat(pathAbsolute)
+			_, err = os.Lstat(pathAbsolute)
 			if err != nil {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.8"
+const version = "v1.7.9"
 
 func main() {
 	//	f, _ := os.Create("profile.prof")

--- a/util.go
+++ b/util.go
@@ -528,6 +528,16 @@ func PathMatchesList(path string, matchList []string) bool {
 	return false
 }
 
+func PathMatchesListCaseInsensitive(path string, matchList []string) bool {
+	for _, match := range matchList {
+		matched, _ := filepath.Match(strings.ToLower(match), strings.ToLower(filepath.Base(path)))
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
 // We could maybe cache this to a certain extent
 func ProgramsAndDescriptionsForFile(fen *Fen) ([]string, []string) {
 	var programs []string


### PR DESCRIPTION
- The `D` key now first deselects files, re-press it to un-yank
- Fixed `Ctrl+Left` to go to the root path not working correctly on Windows
- The `Ctrl+Left` key now goes to the root path of the current Git repository when `fen.git_status = true`
- The `Ctrl+Right` key now goes to the first unstaged/untracked file in a folder when `fen.git_status = true`
- Fixed `--sort-reverse` not working with certain `--sort-by` values
- Added a default file preview blocklist for common sensitive files (\*.key files, FileZilla credentials etc.), set `fen.preview_safety_blocklist = false` to disable
- Folders containing unstaged/untracked files are now shown in red when `fen.git_status = true`
- `fen --select` now works with symlinks
- Lua file preview errors now clear the preview area before showing the error message
- `markdown.lua` file preview: Background of codeblocks now extend to the screen width, trailing backslashes are hidden, and escaped characters don't show a backslash
- Added a Lua file preview script for `go.mod` files