### PR TITLE
Release v1.7.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 `V` Start selecting by moving\
 `n` Create a new file\
 `N` Create a new folder\
-`F5` Refresh files (and refresh git status when `fen.git_status=true`), then syncs the screen, fixes broken output that can be caused by running a command, or filenames with certain Unicode characters\
+`F5` Refreshes files, syncs the screen (fixes possible broken output) and then refreshes git status when `fen.git_status=true`\
 `0-9` Go to a configured bookmark
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ You can find examples in [lua-file-open-examples](lua-file-open-examples)
 - fen intentionally does not handle Unicode "grapheme clusters" (like chinese text) in filenames correctly for performance reasons. You need to manually build fen with the replace directive for my [tcell fork](https://github.com/kivattt/tcell-naively-faster) in the go.mod file removed to show them correctly
 - Symlinks have no special distinction, a folder symlink will appear like a normal folder
 - On FreeBSD, when the disk is full, fen may erroneously show a very large amount of disk space available (like `18.446 EB free`), when in reality there is no available space
-- Deleting files sometimes doesn't work on Windows (due to files being open in another program?)
 - `go test` doesn't work on Windows
 - The color for audio files is invisible in the default Windows Powershell colors, but not cmd or Windows Terminal
 - Bulk-renaming a .git folder on Windows hangs fen forever

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 `V` Start selecting by moving\
 `n` Create a new file\
 `N` Create a new folder\
-`F5` Sync the screen, fixes broken output that can be caused by running a command, or filenames with certain Unicode characters\
+`F5` Refresh files (and refresh git status when `fen.git_status=true`), then syncs the screen, fixes broken output that can be caused by running a command, or filenames with certain Unicode characters\
 `0-9` Go to a configured bookmark
 
 # Configuration

--- a/TODO.md
+++ b/TODO.md
@@ -30,6 +30,7 @@
 - Add right pane disappearing when no preview/folder?
 - Remove local tracked git repository when .git folder not found anymore
 - topbar.go: Show left part of path also with invisible unicode symbols as codepoints highlighted, and also show symlinks in blue like ranger
+- Configurable filespane proportions
 
 - Abstract away this common pattern:
 ```go

--- a/TODO.md
+++ b/TODO.md
@@ -29,6 +29,7 @@
 - A sort of "back arrow" key for going to the last folder we were in
 - Add right pane disappearing when no preview/folder?
 - Remove local tracked git repository when .git folder not found anymore
+- topbar.go: Show left part of path also with invisible unicode symbols as codepoints highlighted, and also show symlinks in blue like ranger
 
 - Abstract away this common pattern:
 ```go

--- a/fen.go
+++ b/fen.go
@@ -446,6 +446,10 @@ func (fen *Fen) UpdatePanes(forceReadDir bool) {
 
 	fen.UpdateSelectingWithV()
 
+	if !fen.config.GitStatus {
+		return
+	}
+
 	defer func() {
 		fen.lastSel = fen.sel
 	}()
@@ -474,7 +478,7 @@ func (fen *Fen) UpdatePanes(forceReadDir bool) {
 		}
 
 		if stat.IsDir() || inRepository != fen.lastInRepository {
-			fen.TriggerGitStatus()
+			fen.TriggerGitStatus() // Redundant os.Lstat() call
 		}
 
 		fen.lastInRepository = inRepository

--- a/fen.go
+++ b/fen.go
@@ -485,7 +485,8 @@ func (fen *Fen) UpdatePanes(forceReadDir bool) {
 			return
 		}
 
-		if stat.IsDir() || inRepository != fen.lastInRepository {
+		// Seems like the fsnotify events don't catch up on FreeBSD, need to always trigger a Git status
+		if stat.IsDir() || inRepository != fen.lastInRepository || runtime.GOOS == "freebsd" {
 			fen.TriggerGitStatus() // TODO: Fix redundant os.Lstat() and TryFindParentGitRepository calls...
 		}
 

--- a/fen.go
+++ b/fen.go
@@ -42,6 +42,8 @@ type Fen struct {
 	helpScreenVisible      *bool
 	librariesScreenVisible *bool
 
+	runningGitStatus bool
+
 	topBar     *TopBar
 	bottomBar  *BottomBar
 	leftPane   *FilesPane
@@ -166,7 +168,7 @@ func (fen *Fen) Init(path string, app *tview.Application, helpScreenVisible *boo
 	fen.fileOperationsHandler = FileOperationsHandler{fen: fen}
 
 	if fen.config.GitStatus {
-		fen.gitStatusHandler = GitStatusHandler{app: app}
+		fen.gitStatusHandler = GitStatusHandler{app: app, fen: fen}
 		fen.gitStatusHandler.Init()
 	}
 

--- a/fen.go
+++ b/fen.go
@@ -501,6 +501,9 @@ func (fen *Fen) TriggerGitStatus() {
 	}
 
 	stat, err := os.Lstat(fen.sel)
+	if err != nil {
+		return
+	}
 
 	var currentRepository string
 	if stat.IsDir() {

--- a/fen.go
+++ b/fen.go
@@ -482,7 +482,7 @@ func (fen *Fen) UpdatePanes(forceReadDir bool) {
 }
 
 // Ask the git status handler to run a "git status" at the currently selected path.
-// It may choose to ignore the request if for example, it would restart a git status on the same path
+// It may choose to ignore the request if for example, it would restart a git status on the same path or fen.git_status is false.
 func (fen *Fen) TriggerGitStatus() {
 	if !fen.config.GitStatus {
 		return

--- a/filespane.go
+++ b/filespane.go
@@ -539,12 +539,24 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 		return
 	}
 
+	x, y, w, h := fp.GetInnerRect()
+
 	if fp.fen.config.UiBorders {
+		gitRepo, gitRepoErr := fp.fen.gitStatusHandler.TryFindParentGitRepository(fp.folder)
+		if gitRepoErr == nil {
+			fp.Box.SetBorderColor(tcell.ColorBlue)
+		} else {
+			fp.Box.SetBorderColor(tcell.ColorDefault)
+		}
+
 		// TODO: Make a custom border drawing so it runs faster
 		fp.Box.DrawForSubclass(screen, fp)
-	}
 
-	x, y, w, h := fp.GetInnerRect()
+		if gitRepoErr == nil {
+			// TODO: Show current branch name, maybe show remote name?
+			tview.Print(screen, filepath.Base(gitRepo), x+1, y-1, w-1, tview.AlignLeft, tcell.ColorBlue)
+		}
+	}
 
 	if fp.isRightFilesPane || fp.fen.config.UiBorders {
 		w++

--- a/filespane.go
+++ b/filespane.go
@@ -325,6 +325,8 @@ func (fp *FilesPane) ChangeDir(path string, forceReadDir bool) {
 	fp.parentIsEmptyFolder = statIsDir && len(fp.entries.Load().([]os.DirEntry)) <= 0
 }
 
+// When a file event happens in a filespane it only sorts itself, but the parent directory might then have a new modified time and thus need to be sorted.
+// This results in an inconsistency with SORT_MODIFIED
 func (fp *FilesPane) FilterAndSortEntries() {
 	if !fp.fen.config.HiddenFiles {
 		withoutHiddenFiles := []os.DirEntry{}

--- a/filespane.go
+++ b/filespane.go
@@ -640,7 +640,11 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 		return
 	}
 
-	gitRepoContainingPath, repoErr := fp.fen.gitStatusHandler.TryFindTrackedParentGitRepository(fp.folder)
+	var gitRepoContainingPath string
+	var repoErr error
+	if fp.fen.config.GitStatus {
+		gitRepoContainingPath, repoErr = fp.fen.gitStatusHandler.TryFindTrackedParentGitRepository(fp.folder)
+	}
 
 	scrollOffset := fp.GetTopScreenEntryIndex()
 	for i, entry := range fp.entries.Load().([]os.DirEntry)[scrollOffset:] {
@@ -667,16 +671,9 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 		} else {
 			// Show unstaged/untracked files in red
 			if fp.fen.config.GitStatus && repoErr == nil {
-				if entry.IsDir() {
-					if fp.fen.gitStatusHandler.FolderContainsUnstagedOrUntrackedPath(entryFullPath, gitRepoContainingPath) {
-						// Same color used in the git status command
-						style = style.Foreground(tcell.ColorMaroon).Bold(false) // Unstaged/untracked file in a git directory, distinct from filetype colors
-					}
-				} else {
-					if fp.fen.gitStatusHandler.PathIsUnstagedOrUntracked(entryFullPath, gitRepoContainingPath) {
-						// Same color used in the git status command
-						style = style.Foreground(tcell.ColorMaroon).Bold(false) // Unstaged/untracked file in a git directory, distinct from filetype colors
-					}
+				if fp.fen.gitStatusHandler.PathIsUnstagedOrUntracked(entryFullPath, gitRepoContainingPath) {
+					// Same color used in the git status command
+					style = style.Foreground(tcell.ColorMaroon).Bold(false) // Unstaged/untracked file in a git directory, distinct from filetype colors
 				}
 			}
 		}

--- a/filespane.go
+++ b/filespane.go
@@ -320,6 +320,7 @@ func (fp *FilesPane) ChangeDir(path string, forceReadDir bool) {
 	} else {
 		fp.fileWatcher.Remove(fp.folder)
 		fp.entries.Store([]os.DirEntry{})
+		fp.folder = path
 	}
 
 	fp.parentIsEmptyFolder = statIsDir && len(fp.entries.Load().([]os.DirEntry)) <= 0

--- a/gitstatushandler.go
+++ b/gitstatushandler.go
@@ -15,6 +15,7 @@ import (
 
 type GitStatusHandler struct {
 	app             *tview.Application
+	fen             *Fen
 	channel         chan string
 	wg              sync.WaitGroup
 	workerWaitGroup sync.WaitGroup
@@ -215,8 +216,10 @@ func (gsh *GitStatusHandler) Init() {
 					panic("GitStatusHandler tried to run StatusWithContext on a non-absolute path: \"" + gsh.repoPathCurrentlyWorkingOn + "\"")
 				}
 
+				gsh.fen.runningGitStatus = true
 				changedFiles, err := gogitstatus.StatusWithContext(gsh.ctx, gsh.repoPathCurrentlyWorkingOn)
 				if err != nil {
+					gsh.fen.runningGitStatus = false // Can't defer this because it has to run before QueueUpdateDraw()
 					return
 				}
 
@@ -227,6 +230,7 @@ func (gsh *GitStatusHandler) Init() {
 				}
 				gsh.trackedLocalGitReposMutex.Unlock()
 
+				gsh.fen.runningGitStatus = false // Can't defer this because it has to run before QueueUpdateDraw()
 				gsh.app.QueueUpdateDraw(func() {})
 			}()
 		}

--- a/gitstatushandler.go
+++ b/gitstatushandler.go
@@ -114,6 +114,7 @@ func (gsh *GitStatusHandler) Init() {
 	gsh.gitIndexFileWatcher, _ = fsnotify.NewWatcher()
 
 	// Git index file watcher
+	// This is so we update in real-time on "git add" / "git restore"
 	go func() {
 		for {
 			select {
@@ -136,6 +137,7 @@ func (gsh *GitStatusHandler) Init() {
 					}
 
 					if len(watchList) == 1 {
+						// TODO: Make this forcefully re-run the StatusWithContext()
 						gsh.channel <- filepath.Dir(watchList[0])
 					}
 				}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/kivattt/getopt v0.0.0-20240907012637-674e0e42e04f
-	github.com/kivattt/gogitstatus v0.0.0-20241025103638-d9516b2a89c5
+	github.com/kivattt/gogitstatus v0.0.0-20241102160917-9feffc03ed74
 	github.com/otiai10/copy v1.14.0
 	github.com/rivo/tview v0.0.0-20241030223020-e34b54cd4c27
 	github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/kivattt/getopt v0.0.0-20240907012637-674e0e42e04f h1:myfMHJX0b7esBOYu
 github.com/kivattt/getopt v0.0.0-20240907012637-674e0e42e04f/go.mod h1:XbVdQu8SHHjoqISPmGcFvHQ8xFuutDrbc4pdw1US62s=
 github.com/kivattt/gogitstatus v0.0.0-20241025103638-d9516b2a89c5 h1:YP6eCig/6jJ6PeAfym5Aq+Fh6ANhUhFNKi6hEvFI04g=
 github.com/kivattt/gogitstatus v0.0.0-20241025103638-d9516b2a89c5/go.mod h1:PnoARDQ/sJtGyx+UYcX2OqHjbA4akv7oj1b3CmncZLs=
+github.com/kivattt/gogitstatus v0.0.0-20241102160917-9feffc03ed74 h1:s5vKuwIPBYXZgkSJSsCVlxzvWxenzLrNugKrS7EHFOQ=
+github.com/kivattt/gogitstatus v0.0.0-20241102160917-9feffc03ed74/go.mod h1:PnoARDQ/sJtGyx+UYcX2OqHjbA4akv7oj1b3CmncZLs=
 github.com/kivattt/tcell-naively-faster/v2 v2.0.1 h1:+kTjmvCYTLoEb7evW3UoJM3lMaV+TQKaVzAou2xMoqw=
 github.com/kivattt/tcell-naively-faster/v2 v2.0.1/go.mod h1:2tg6gQmD3C2WJK0NBUrWnjIV6nSjv+j5w/+monQdfVI=
 github.com/kivattt/tview v1.0.4 h1:ZPydRJOzzmopB66x1M3G1v8oiRDcCvtCHFeJPo5VXRo=

--- a/helpscreen.go
+++ b/helpscreen.go
@@ -58,7 +58,7 @@ var helpScreenControlsList = []control{
 	{KeyBindings: []string{"A"}, Description: "Flip selection in folder (select all files)"},
 	{KeyBindings: []string{"V"}, Description: "Start selecting by moving"},
 	{KeyBindings: []string{"D"}, Description: "Deselect all, press again to un-yank"},
-	{KeyBindings: []string{"F5"}, Description: "Sync the screen"},
+	{KeyBindings: []string{"F5"}, Description: "Refresh files, sync screen"},
 	{KeyBindings: []string{"0-9"}, Description: "Go to a configured bookmark"},
 }
 

--- a/librariesscreen.go
+++ b/librariesscreen.go
@@ -36,7 +36,7 @@ var librariesList = []library{
 	{name: "gluamapper", url: "https://github.com/yuin/gluamapper", version: "commit d836955", license: "MIT", licenseURL: "https://github.com/yuin/gluamapper/blob/master/LICENSE"},
 	{name: "gopher-luar", url: "https://layeh.com/gopher-luar", version: "v1.0.11", license: "MPL 2.0", licenseURL: "https://github.com/layeh/gopher-luar/blob/master/LICENSE"},
 	{name: "rsc/getopt", url: "https://github.com/rsc/getopt", customRevisionURL: "https://github.com/kivattt/getopt", license: "BSD 3-Clause", licenseURL: "https://github.com/rsc/getopt/blob/master/LICENSE"},
-	{name: "kivattt/gogitstatus", url: "https://github.com/kivattt/gogitstatus", version: "commit d9516b2", license: "MIT", licenseURL: "https://github.com/kivattt/gogitstatus/blob/main/LICENSE"},
+	{name: "kivattt/gogitstatus", url: "https://github.com/kivattt/gogitstatus", version: "commit 9feffc0", license: "MIT", licenseURL: "https://github.com/kivattt/gogitstatus/blob/main/LICENSE"},
 }
 
 func (librariesScreen *LibrariesScreen) Draw(screen tcell.Screen) {

--- a/main.go
+++ b/main.go
@@ -990,8 +990,8 @@ func main() {
 			return nil
 		} else if event.Key() == tcell.KeyF5 {
 			fen.UpdatePanes(true)
-			fen.TriggerGitStatus()
 			app.Sync()
+			fen.TriggerGitStatus()
 			return nil
 		} else if event.Rune() >= '0' && event.Rune() <= '9' {
 			err := fen.GoBookmark(int(event.Rune()) - '0')

--- a/main.go
+++ b/main.go
@@ -677,7 +677,11 @@ func main() {
 					if !fen.config.NoWrite && err != nil {
 						var createFileOrFolderErr error
 						if event.Rune() == 'n' {
-							_, createFileOrFolderErr = os.Create(pathToUse)
+							var file *os.File
+							file, createFileOrFolderErr = os.Create(pathToUse)
+							if createFileOrFolderErr == nil {
+								defer file.Close()
+							}
 						} else if event.Rune() == 'N' {
 							createFileOrFolderErr = os.Mkdir(pathToUse, 0775)
 						}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.10"
+const version = "v1.7.11"
 
 func main() {
 	//	f, _ := os.Create("profile.prof")
@@ -989,6 +989,8 @@ func main() {
 			app.SetFocus(inputField)
 			return nil
 		} else if event.Key() == tcell.KeyF5 {
+			fen.UpdatePanes(true)
+			fen.TriggerGitStatus()
 			app.Sync()
 			return nil
 		} else if event.Rune() >= '0' && event.Rune() <= '9' {

--- a/main.go
+++ b/main.go
@@ -30,12 +30,20 @@ func main() {
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault
 
 	tview.Styles.BorderColor = tcell.ColorDefault
-	tview.Borders.TopLeft = '╭'
-	tview.Borders.TopRight = '╮'
-	tview.Borders.BottomLeft = '╰'
-	tview.Borders.BottomRight = '╯'
 	tview.Borders.Horizontal = '─'
 	tview.Borders.Vertical = '│'
+
+	if runtime.GOOS == "freebsd" {
+		tview.Borders.TopLeft = '┌'
+		tview.Borders.TopRight = '┐'
+		tview.Borders.BottomLeft = '└'
+		tview.Borders.BottomRight = '┘'
+	} else {
+		tview.Borders.TopLeft = '╭'
+		tview.Borders.TopRight = '╮'
+		tview.Borders.BottomLeft = '╰'
+		tview.Borders.BottomRight = '╯'
+	}
 
 	userConfigDir, err := os.UserConfigDir()
 	defaultConfigFilenamePath := ""

--- a/topbar.go
+++ b/topbar.go
@@ -77,4 +77,8 @@ func (topBar *TopBar) Draw(screen tcell.Screen) {
 	if topBar.showAdditionalText {
 		tview.Print(screen, "« "+topBar.additionalText, x+usernameAndHostnameLength+1+pathPrintedLength+1, y, w, tview.AlignLeft, tcell.ColorDefault)
 	}
+
+	if topBar.fen.runningGitStatus {
+		tview.Print(screen, "Refreshing Git status...", x, y, w, tview.AlignRight, tcell.ColorDefault)
+	}
 }

--- a/util.go
+++ b/util.go
@@ -924,13 +924,23 @@ func PrintFilenameInvisibleCharactersAsCodeHighlighted(screen tcell.Screen, x, y
 				screen.SetContent(x+offset, y, '…', nil, style)
 			}
 			offset++
-			break
+			return offset
 		}
 
 		// Use printable codes for leading and trailing invisible or non-printable runes
 		if i < leadingInvisibleOrNonPrintableCharLength || len(filename)-i <= trailingInvisibleOrNonPrintableCharLength {
 			printableCode := RuneToPrintableCode(c)
 			for _, character := range printableCode {
+				if offset >= maxWidth-2 {
+					if runtime.GOOS == "freebsd" {
+						screen.SetContent(x+offset, y, '~', nil, style)
+					} else {
+						screen.SetContent(x+offset, y, '…', nil, style)
+					}
+					offset++
+					return offset
+				}
+
 				screen.SetContent(x+offset, y, character, nil, tcell.StyleDefault.Background(tcell.ColorDarkRed))
 				offset++
 			}
@@ -942,6 +952,16 @@ func PrintFilenameInvisibleCharactersAsCodeHighlighted(screen tcell.Screen, x, y
 		if c != ' ' && isInvisible(c) {
 			printableCode := RuneToPrintableCode(c)
 			for _, character := range printableCode {
+				if offset >= maxWidth-2 {
+					if runtime.GOOS == "freebsd" {
+						screen.SetContent(x+offset, y, '~', nil, style)
+					} else {
+						screen.SetContent(x+offset, y, '…', nil, style)
+					}
+					offset++
+					return offset
+				}
+
 				screen.SetContent(x+offset, y, character, nil, tcell.StyleDefault.Background(tcell.ColorDarkRed))
 				offset++
 			}

--- a/util.go
+++ b/util.go
@@ -1047,6 +1047,10 @@ func StringSliceHasDuplicate(strSlice []string) (string, error) {
 
 // Returns a random string of length numCharacters containing lowercase a-z and 0-9.
 func RandomStringPathSafe(numCharacters int) string {
+	if numCharacters < 0 {
+		numCharacters = 0
+	}
+
 	// It is important not to use mixed case characters because some filesystems are case-insensitive
 	alphabet := "abcdefghijklmnopqrstuvwxyz0123456789"
 	b := make([]byte, numCharacters)

--- a/util_test.go
+++ b/util_test.go
@@ -116,3 +116,43 @@ func TestMapStringBoolKeys(t *testing.T) {
 		}
 	}
 }
+
+func TestStringSliceHasDuplicate(t *testing.T) {
+	s := []string{"hello", "world", "", "hi"}
+	_, err := StringSliceHasDuplicate(s)
+	if err == nil {
+		t.Fatal("Expected an error, but got nil")
+	}
+
+	s = []string{}
+	_, err = StringSliceHasDuplicate(s)
+	if err == nil {
+		t.Fatal("Expected an error, but got nil")
+	}
+
+	s = []string{"", ""}
+	found, err := StringSliceHasDuplicate(s)
+	if err != nil {
+		t.Fatal("Expected no error, but got: " + err.Error())
+	}
+	if found != "" {
+		t.Fatal("Expected \"\", but got: " + found)
+	}
+}
+
+func TestRandomStringPathSafe(t *testing.T) {
+	r := RandomStringPathSafe(0)
+	if r != "" {
+		t.Fatal("Expected \"\", but got: " + r)
+	}
+
+	r = RandomStringPathSafe(1)
+	if len(r) != 1 {
+		t.Fatal("Expected len(r) == 1, but got: " + strconv.Itoa(len(r)))
+	}
+
+	r = RandomStringPathSafe(-1)
+	if r != "" {
+		t.Fatal("Expected \"\" (for -1 length), but got: " + r)
+	}
+}


### PR DESCRIPTION
- Fixed a bug on Windows where creating a new file would not close the handle, meaning it was impossible to delete while fen is open
- Fixed a bug on FreeBSD where the right pane would show "empty" when going to the left after making a new file
- F5 key now refreshes files, syncs the screen and then refreshes Git status if `fen.git_status = true`
- `markdown.lua` file preview now supports thematic breaks and `*` character for list items

### `fen.ui_borders = true` changes:
- Git repositories now have a blue border and show the name of the root repository folder
- Fixed the edge characters showing as `?` on FreeBSD by using square edge characters
- Fixed a bug where printed escaped Unicode characters would draw over the border

### `fen.git_status = true` changes:
- Fixed a performance issue introduced in v1.7.9 related to coloring folders containing unstaged/untracked files
- Automatically refreshes the Git status when `git add` or `git revoke` is ran by watching the `.git/index` file in the current Git repository
- Added a "Refreshing Git status..." message in the top-right while refreshing a Git repository
- (Doesn't apply to FreeBSD) Reduced CPU usage by not refreshing the Git status when scrolling through files (not folders)