### PR TITLE
Release v1.7.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Download and run the latest version in the [Releases](https://github.com/kivattt
 Add it to your path environment variable, or (on Linux/FreeBSD) place the executable in `/usr/local/bin`
 
 ### Building from source
-This requires Go 1.21.5 or above [install Go](https://go.dev/dl/)
+This requires Go 1.21.5 or above ([install Go](https://go.dev/dl/))
 ```
 git clone https://github.com/kivattt/fen
 cd fen

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ alias fen=cd_fen
 NOTE: Using this alias will break command-line arguments, like `fen -v` since the output will be passed to `cd`.
 
 <details>
-<summary><h1>Lua scripting (click to expand)</h1></summary>
+<summary><h2>Lua scripting (click to expand)</h2></summary>
 
 fen uses [gopher-lua](https://github.com/yuin/gopher-lua) as its Lua runtime.
 

--- a/README.md
+++ b/README.md
@@ -12,23 +12,22 @@ Works for Linux, macOS, FreeBSD and Windows
 <img src="screenshots/windows.png" alt="fen running on Windows, showing the open-with modal" width="48%">
 </p>
 
-# Try it out now!
+## Installing
+### Prebuilt binaries
+Download and run the latest version in the [Releases](https://github.com/kivattt/fen/releases) page
+
+Add it to your path environment variable, or (on Linux/FreeBSD) place the executable in `/usr/local/bin`
+
+### Building from source
+This requires Go 1.21.5 or above [install Go](https://go.dev/dl/)
 ```
 git clone https://github.com/kivattt/fen
 cd fen
-go build # Install Go: https://go.dev/dl/
+go build
 ./fen # fen.exe on Windows
 ```
 
-# Installing on Linux/FreeBSD
-Download the latest version in the [Releases](https://github.com/kivattt/fen/releases) page, and put it inside `/usr/local/bin`
-
-Alternatively:
-```
-sudo -i GOBIN=/usr/local/bin go install github.com/kivattt/fen@latest
-```
-
-# Controls
+## Controls
 Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Escape key to cancel an action
 
 `?` or `F1` Toggle help menu\
@@ -62,7 +61,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 `F5` Refreshes files, syncs the screen (fixes possible broken output) and then refreshes git status when `fen.git_status=true`\
 `0-9` Go to a configured bookmark
 
-# Configuration
+## Configuration
 You can find a complete default config with extra examples in the [config.lua](config.lua) file\
 For a full config folder example, see [my personal config](https://github.com/kivattt/dotfiles/blob/main/.config/fen/config.lua)
 
@@ -74,7 +73,7 @@ You can specify a different config file with the `--config` flag
 
 Left-clicking to copy the selected path on Linux/FreeBSD requires `xclip` to be installed
 
-# File previews
+## File previews
 fen does not (yet!) have file previews by default\
 For file previews with programs like `cat` or `head`, you can add something like this to your config.lua:
 ```lua
@@ -99,7 +98,7 @@ If "script" is set, "program" will be ignored in the same preview entry.\
 "script" can not be a list like "program" can, because we want to see syntax errors when writing lua code instead of falling back to anything.\
 The "script" key has to be an absolute file path
 
-# Changing directory
+## Changing directory
 You can change the current working directory to the one in fen on exit:
 ```bash
 cd $(fen --print-folder-on-exit)
@@ -154,7 +153,7 @@ You can find examples in [lua-file-open-examples](lua-file-open-examples)
 `fen.Version` fen version string
 </details>
 
-# Known issues
+## Known issues
 - fen may crash in the middle of deleting files due to a data race, most commonly when deleting a lot of files (like 4000)
 - File previews are ran synchronously, which means they slow down fen
 - fen intentionally does not handle Unicode "grapheme clusters" (like chinese text) in filenames correctly for performance reasons. You need to manually build fen with the replace directive for my [tcell fork](https://github.com/kivattt/tcell-naively-faster) in the go.mod file removed to show them correctly

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 ## TODOs, vaguely sorted by priority
 
-- Bulk rename
 - Scrollable search history
 - Better scrolling
 - It sometimes exits badly, stuff is left on screen ever since async file operations were added
@@ -11,14 +10,11 @@
 - Changing owner/group, chmod inside fen (probably not, since you can do it with open-with)
 - Make draw functions for top bar / bottom bar scriptable with lua
 - Global selection (selection stored in a file under UserCacheDir ?)
-- A sort of "pause" (cross-platform please) after opening a file, configurable, maybe excluding it for certain programs like vim
-- Shortcuts / bookmarks (think the 1,2,3,4 number row idea (maybe Ctrl+\<Number\> for it?)
 - Ctrl+Shift+n, Ctrl+Shift+n search by content, search by path name like telescope
 - Check if [dragon](https://github.com/mwh/dragon) works, maybe just make my own built into fen with some gtk wrapper? (bad idea lol)
 - Show current folder size beside disk size?
 - A sort of --no-unicode option, to print the character codes instead of fancy unicode characters
 - Configuration: Matching based on file permission flags (like executables)? (Maybe not now that we have open Lua scripts
-- Handle symlinks (show them as separate colors / a " ->" after file size in filespane.go (symlinks also mess with FoldersAtBeginning())
 - Configurable colors / respect LS\_COLORS?
 - Fix a crash (fen hanging) on something like `/proc/.../oom_score_adj`
 - Fix the bottom bar sometimes not showing info on files inside `/proc/.../map_files`
@@ -45,7 +41,6 @@ if strings.HasPrefix(rel, "..") {
 }
 ```
 
-- Ctrl+Right arrow goes to end of history
 - File list mode ("flattened mode", "flattened folder view" ?)
   - Recursive directory iterator in separate thread updating the entries
   - Color change in UI, like (red? maybe something friendlier...) background for the topbar
@@ -54,24 +49,16 @@ if strings.HasPrefix(rel, "..") {
   - Show more file info in filespane drawing
 
 - System-wide configuration file instructions
-- Make file previews not run every time the terminal is resized?
 - Installation instructions for Windows in the README
 - Allow spaces in "programs" path in config with `\ `? (Maybe not, this might be annoying on Windows), maybe add os package ExpandEnv to allow using environment variables in "programs"
 - .deb file in Releases
-- Fix selecting text with mouse when noMouse = false
 - Allow opening images with 'feh', fix it not breaking fen, 'xviewer' can also break fen rarely
 - Make the "open with" modal a selectable list with tab/shift+tab controls aswell as arrow keys, would replace inputfield placeholder and reset input text to blank
 - Configurable keybindings
 - Configurable custom themes by changing `tview.Styles`
-- Jump to file/folder created on n/N
-- Commands like :mkdir etc.?
-- Fix some hidden file toggle bugs?
 - Disallow recursive copies or whatever
-- (Maybe...) Vim/ranger stuff like `5<space>` selecting 5 files, or `5j` going down 5
-- 'n' is a little too close to 'M', maybe change it?
 - Fix `history_test.go` for Windows paths
 - Fix green color for all executables (the current bitmask check doesn't work for everything)
 - Fix invisibility near root dir (easy to see on Android with Termux)
-- Performance: Caching stuff (maybe only re-dirlist for left/right)
 - `H` and `L` controls feel weird because the screen scrolls in a specific way instead of just setting the cursor to the bottom of the screen like the behaviour in vim
 - Optional xdg trash specification? https://specifications.freedesktop.org/trash-spec/trashspec-latest.html

--- a/config.lua
+++ b/config.lua
@@ -25,7 +25,7 @@ print(fen.version) -- Something like "v1.6.6"
 -- The current operating system
 print(fen.runtime_os) -- "linux", "darwin" (for macOS), "freebsd", "windows"
 
--- The OS-specific config path
+-- The OS-specific config path OR parent directory of `--config` argument
 print(fen.config_path) -- Something like "/home/YOUR_USER/.config/fen/" (always ends in a slash)
 
 -- The OS-specific home folder (nil if not found), details: https://pkg.go.dev/os#UserHomeDir

--- a/fen.go
+++ b/fen.go
@@ -36,6 +36,7 @@ type Fen struct {
 	selectedBeforeSelectingWithV map[string]bool
 
 	config                Config
+	configPath            string // Config path as read by ReadConfig()
 	fileOperationsHandler FileOperationsHandler
 	gitStatusHandler      GitStatusHandler
 
@@ -254,6 +255,7 @@ func (fen *Fen) Fini() {
 
 func (fen *Fen) ReadConfig(path string) error {
 	fen.config = NewConfigDefaultValues()
+	fen.configPath = path
 
 	if !strings.HasSuffix(filepath.Base(path), ".lua") {
 		fmt.Fprintln(os.Stderr, "Warning: Config file "+path+" has no .lua file extension.\nSince v1.3.0, config files can only be Lua.\n")
@@ -292,9 +294,8 @@ func (fen *Fen) ReadConfig(path string) error {
 		}
 	}
 
-	userConfigDir, err := os.UserConfigDir()
 	if err == nil {
-		luaInitialConfigTable.RawSetString("config_path", lua.LString(PathWithEndSeparator(filepath.Join(userConfigDir, "fen"))))
+		luaInitialConfigTable.RawSetString("config_path", lua.LString(PathWithEndSeparator(filepath.Dir(fen.configPath))))
 	}
 	luaInitialConfigTable.RawSetString("version", lua.LString(version))
 	luaInitialConfigTable.RawSetString("runtime_os", lua.LString(runtime.GOOS))

--- a/lua-file-preview-examples/gitignore.lua
+++ b/lua-file-preview-examples/gitignore.lua
@@ -1,0 +1,48 @@
+--[[
+-- File preview for .gitignore files in Git repositories
+--]]
+
+local function isSpecialChar(char)
+	return char == '/' or char == '*' or char == '?'
+end
+
+-- Customize the colors here:
+local commentColor = "[teal]"
+local specialCharColor = "[orange]"
+local captureColor = "[aqua]"
+
+local y = 0
+local inCapture = false
+for line in io.lines(fen.SelectedFile) do
+	if line:sub(1,1) == '#' then
+		fen:PrintSimple(commentColor..line, 0, y)
+		goto continue
+	end
+
+	for i = 1, #line do
+		local style = ""
+		local c = line:sub(i,i)
+
+		if not inCapture and c == '[' then
+			inCapture = true
+		end
+
+		if inCapture then
+			style = captureColor
+		elseif isSpecialChar(c) then
+			style = specialCharColor
+		end
+
+		if inCapture and c == ']' then
+			inCapture = false
+		end
+
+		fen:PrintSimple(style..c, i-1, y)
+	end
+
+    ::continue::
+	y = y + 1
+	if y >= fen.Height then
+		break
+	end
+end

--- a/lua-file-preview-examples/go.mod.lua
+++ b/lua-file-preview-examples/go.mod.lua
@@ -19,7 +19,7 @@ for line in io.lines(fen.SelectedFile) do
 	local style = ""
 
 	if line:sub(1,2) == "//" then
-		style = "[blue::d]"
+		style = "[teal]"
 	elseif line:sub(1, #replace) == replace then
 		local separator = line:find("=>")
 		if separator ~= nil then

--- a/lua-file-preview-examples/go.mod.lua
+++ b/lua-file-preview-examples/go.mod.lua
@@ -1,7 +1,6 @@
 --[[
 -- File preview for go.mod files in Golang projects
 --]]
---
 local function trimLeftAndRightSpaces(s)
    return (s:gsub("^%s*(.-)%s*$", "%1"))
 end

--- a/lua-file-preview-examples/go.mod.lua
+++ b/lua-file-preview-examples/go.mod.lua
@@ -34,11 +34,11 @@ for line in io.lines(fen.SelectedFile) do
 
 		style = "[yellow]"
 	elseif line:sub(-#indirect) == indirect then
-		style = "[gray::d]"
+		style = "[gray]"
 	elseif line:sub(1, #module) == module then
-		style = "[lime]"
+		style = "[yellow]"
 	elseif line:sub(1, #go) == go then
-		style = "[blue]"
+		style = "[yellow]"
 	elseif line:sub(1, #require) == require then
 		style = "[yellow]"
 	elseif line == ")" then

--- a/lua-file-preview-examples/markdown.lua
+++ b/lua-file-preview-examples/markdown.lua
@@ -148,14 +148,16 @@ for line in io.lines(fen.SelectedFile) do
 
 	local lineLength = 0
 	for i = 1, #line do
+		char = line:sub(i,i)
+
 		-- Remove single trailing backslash if present
 		if i == #line then
-			if line:sub(i,i) == '\\' then
+			if char == '\\' then
+				lastChar = char
 				goto continue
 			end
 		end
 
-		char = line:sub(i,i)
 		local peekChar = line:sub(i+1,i+1)
 		if i == #line - 1 then
 			peekChar = ""
@@ -171,7 +173,6 @@ for line in io.lines(fen.SelectedFile) do
 			if char == '`' and lastChar ~= '`' then
 				backtickString = not backtickString
 				-- It messes up table alignment if we skip over the backticks, so we just replace them with blank space instead
-				--xOffset = xOffset - 1
 				fen:PrintSimple("[:black] ", i+xOffset-1, y)
 				lastChar = char
 				goto continue

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.11"
+const version = "v1.7.12"
 
 func main() {
 	//	f, _ := os.Create("profile.prof")

--- a/util.go
+++ b/util.go
@@ -666,9 +666,8 @@ func OpenFile(fen *Fen, app *tview.Application, openWith string) {
 				L := lua.NewState()
 				defer L.Close()
 
-				userConfigDir, _ := os.UserConfigDir()
 				fenOpenWithLuaGlobal := &FenOpenWithLuaGlobal{
-					ConfigPath: PathWithEndSeparator(filepath.Join(userConfigDir, "fen")),
+					ConfigPath: PathWithEndSeparator(filepath.Dir(fen.configPath)),
 					Version:    version,
 					RuntimeOS:  runtime.GOOS,
 				}


### PR DESCRIPTION
- Fixed a bug where `fen.config_path` in config.lua and `fen.ConfigPath` in file open scripts would not respect the `--config` command-line flag
- Improved installation instructions in the README

### File preview changes:
- Added a .gitignore file preview script `gitignore.lua`
- `go.mod.lua` Comments are now colored teal
- `go.mod.lua` has less distracting colors
- `markdown.lua` Fixed a bug where backtick strings would not stop at the end of lines with a trailing backslash