### PR TITLE
Release v1.7.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 <kbd>z</kbd> or <kbd>Backspace</kbd> Toggle hidden files\
 <kbd>Ctrl + Space</kbd> or <kbd>Ctrl + n</kbd> Open file(s) with specific program\
 <kbd>!</kbd> Run system shell command (cmd on Windows)\
-<kbd>Home</kbd> or <kbd>g</kbd> to go to the top\
-<kbd>End</kbd> or <kbd>G</kbd> to go to the bottom\
-<kbd>Ctrl + Left arrow</kbd> to go to the root folder (or current Git repository if `fen.git_status=true`)\
-<kbd>Ctrl + Right arrow</kbd> to go to the path furthest down in history (or first changed file if `fen.git_status=true`)\
+<kbd>Home</kbd> or <kbd>g</kbd> Go to the top\
+<kbd>End</kbd> or <kbd>G</kbd> Go to the bottom\
+<kbd>Ctrl + Left arrow</kbd> Go to the root folder (or current Git repository if `fen.git_status=true`)\
+<kbd>Ctrl + Right arrow</kbd> Go to the path furthest down in history (or first changed file if `fen.git_status=true`)\
 <kbd>M</kbd> Go to the middle\
 <kbd>Page Up</kbd> / <kbd>Page Down</kbd> Scroll up/down an entire page\
 <kbd>H</kbd> Go to the top of the screen\

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 <kbd>V</kbd> Start selecting by moving\
 <kbd>n</kbd> Create a new file\
 <kbd>N</kbd> Create a new folder\
-<kbd>F5</kbd> Refreshes files, syncs the screen (fixes possible broken output) and then refreshes git status when `fen.git_status=true`\
+<kbd>F5</kbd> Refreshes files, syncs the screen (fixes possible broken output), refreshes git status when `fen.git_status=true`\
 <kbd>0-9</kbd> Go to a configured bookmark
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 <kbd>V</kbd> Start selecting by moving\
 <kbd>n</kbd> Create a new file\
 <kbd>N</kbd> Create a new folder\
-<kbd>F5</kbd> Refreshes files, syncs the screen (fixes possible broken output), refreshes git status when `fen.git_status=true`\
+<kbd>F5</kbd> Refreshes files, syncs the screen (fixes broken output), refreshes git status when `fen.git_status=true`\
 <kbd>0-9</kbd> Go to a configured bookmark
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 <kbd>End</kbd> or <kbd>G</kbd> to go to the bottom\
 <kbd>Ctrl + Left arrow</kbd> to go to the root folder (or current Git repository if `fen.git_status=true`)\
 <kbd>Ctrl + Right arrow</kbd> to go to the path furthest down in history (or first changed file if `fen.git_status=true`)\
-<kbd>M<kbd> Go to the middle\
+<kbd>M</kbd> Go to the middle\
 <kbd>Page Up</kbd> / <kbd>Page Down</kbd> Scroll up/down an entire page\
 <kbd>H</kbd> Go to the top of the screen\
 <kbd>L</kbd> Go to the bottom of the screen\

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 <kbd>Home</kbd> or <kbd>g</kbd> Go to the top\
 <kbd>End</kbd> or <kbd>G</kbd> Go to the bottom\
 <kbd>Ctrl + Left arrow</kbd> Go to the root folder (or current Git repository if `fen.git_status=true`)\
-<kbd>Ctrl + Right arrow</kbd> Go to the path furthest down in history (or first changed file if `fen.git_status=true`)\
+<kbd>Ctrl + Right arrow</kbd> Go to the path furthest down in history, follow a symlink or go to the first changed file if `fen.git_status=true`\
 <kbd>M</kbd> Go to the middle\
 <kbd>Page Up</kbd> / <kbd>Page Down</kbd> Scroll up/down an entire page\
 <kbd>H</kbd> Go to the top of the screen\

--- a/README.md
+++ b/README.md
@@ -30,36 +30,36 @@ go build
 ## Controls
 Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Escape key to cancel an action
 
-`?` or `F1` Toggle help menu\
-`F2` Show libraries used in fen\
-`q` Quit fen\
-`z` or `Backspace` Toggle hidden files\
-`Ctrl + Space` or `Ctrl + n` Open file(s) with specific program\
-`!` Run system shell command (cmd on Windows)\
-`Home` or `g` to go to the top\
-`End` or `G` to go to the bottom\
-`Ctrl + Left arrow` to go to the root folder (or current Git repository if `fen.git_status=true`)\
-`Ctrl + Right arrow` to go to the path furthest down in history (or first changed file if `fen.git_status=true`)\
-`M` Go to the middle\
-`Page Up` / `Page Down` Scroll up/down an entire page\
-`H` Go to the top of the screen\
-`L` Go to the bottom of the screen\
-`Del` or `x` Delete file(s)\
-`y` Copy file(s)\
-`d` Cut file(s)\
-`p` Paste file(s)\
-`/` or `Ctrl + f` Search\
-`c` Goto path\
-`Space` Select files\
-`A` Flip selection in folder (select all files)\
-`D` Deselect all, press again to un-yank\
-`a` Rename a file\
-`b` Bulk-rename (rename in editor)\
-`V` Start selecting by moving\
-`n` Create a new file\
-`N` Create a new folder\
-`F5` Refreshes files, syncs the screen (fixes possible broken output) and then refreshes git status when `fen.git_status=true`\
-`0-9` Go to a configured bookmark
+<kbd>?</kbd> or <kbd>F1</kbd> Toggle help menu\
+<kbd>F2</kbd> Show libraries used in fen\
+<kbd>q</kbd> Quit fen\
+<kbd>z</kbd> or <kbd>Backspace</kbd> Toggle hidden files\
+<kbd>Ctrl + Space</kbd> or <kbd>Ctrl + n</kbd> Open file(s) with specific program\
+<kbd>!</kbd> Run system shell command (cmd on Windows)\
+<kbd>Home</kbd> or <kbd>g</kbd> to go to the top\
+<kbd>End</kbd> or <kbd>G</kbd> to go to the bottom\
+<kbd>Ctrl + Left arrow</kbd> to go to the root folder (or current Git repository if `fen.git_status=true`)\
+<kbd>Ctrl + Right arrow</kbd> to go to the path furthest down in history (or first changed file if `fen.git_status=true`)\
+<kbd>M<kbd> Go to the middle\
+<kbd>Page Up</kbd> / <kbd>Page Down</kbd> Scroll up/down an entire page\
+<kbd>H</kbd> Go to the top of the screen\
+<kbd>L</kbd> Go to the bottom of the screen\
+<kbd>Del</kbd> or <kbd>x</kbd> Delete file(s)\
+<kbd>y</kbd> Copy file(s)\
+<kbd>d</kbd> Cut file(s)\
+<kbd>p</kbd> Paste file(s)\
+<kbd>/</kbd> or <kbd>Ctrl + f</kbd> Search\
+<kbd>c</kbd> Goto path\
+<kbd>Space</kbd> Select files\
+<kbd>A</kbd> Flip selection in folder (select all files)\
+<kbd>D</kbd> Deselect all, press again to un-yank\
+<kbd>a</kbd> Rename a file\
+<kbd>b</kbd> Bulk-rename (rename in editor)\
+<kbd>V</kbd> Start selecting by moving\
+<kbd>n</kbd> Create a new file\
+<kbd>N</kbd> Create a new folder\
+<kbd>F5</kbd> Refreshes files, syncs the screen (fixes possible broken output) and then refreshes git status when `fen.git_status=true`\
+<kbd>0-9</kbd> Go to a configured bookmark
 
 ## Configuration
 You can find a complete default config with extra examples in the [config.lua](config.lua) file\

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@
 - Remove local tracked git repository when .git folder not found anymore
 - topbar.go: Show left part of path also with invisible unicode symbols as codepoints highlighted, and also show symlinks in blue like ranger
 - Configurable filespane proportions
+- Warn when deleting hidden files while hidden files aren't visible
 
 - Abstract away this common pattern:
 ```go

--- a/fen.go
+++ b/fen.go
@@ -884,6 +884,8 @@ func (fen *Fen) GoIndex(index int) {
 // On completion, it always adds fen.sel to the history.
 // Implicitly calls fen.UpdatePanes(false) when no error.
 func (fen *Fen) GoPath(path string) (string, error) {
+	// TODO: Add an option to not enter directories
+
 	/* PLUGINS:
 	 * We should fen.UpdatePanes(true) when we can't find the newPath in the current middlePane (for going to path on renaming)
 	 * This would slow down "Goto path" when going to a non-existent path, but would guarantee this function always works predictably
@@ -1016,6 +1018,23 @@ func (fen *Fen) GoRightUpToFirstUnstagedOrUntracked(repoPath, currentPath string
 	}
 
 	_, err := fen.GoPath(filepath.Join(currentPath, changedFileClosestToRoot))
+	return err
+}
+
+// Resolves the symlink and uses fen.GoPath() under the hood
+func (fen *Fen) GoSymlink(symlinkPath string) error {
+	// Should not happen
+	if !filepath.IsAbs(symlinkPath) {
+		return errors.New("Selected file was not an absolute path")
+	}
+
+	target, err := os.Readlink(fen.sel)
+	if err != nil {
+		return errors.New("Unable to readlink selected file")
+	}
+
+	// FIXME: GoPath() enters directories, when we don't want to (need to Lstat the target)
+	_, err = fen.GoPath(target)
 	return err
 }
 

--- a/fen.go
+++ b/fen.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kivattt/gogitstatus"
 	"github.com/rivo/tview"
 	"github.com/yuin/gluamapper"
 	lua "github.com/yuin/gopher-lua"
@@ -978,6 +979,7 @@ func (fen *Fen) GoRightUpToHistory() {
 }
 
 // Goes to a random unstaged/untracked file from the currently selected folder
+// It will select the shortest filepath, if there are filepaths of equal length they will be chosen at random
 // TODO: Implement sorting function in gogitstatus so this is deterministic
 func (fen *Fen) GoRightUpToFirstUnstagedOrUntracked(repoPath, currentPath string) error {
 	fen.gitStatusHandler.trackedLocalGitReposMutex.Lock()
@@ -989,7 +991,7 @@ func (fen *Fen) GoRightUpToFirstUnstagedOrUntracked(repoPath, currentPath string
 	}
 
 	changedFileClosestToRoot := ""
-	for changedFilePath := range repo.changedFiles {
+	for changedFilePath := range gogitstatus.ExcludingDirectories(repo.changedFiles) {
 		bruhRel, bruhErr := filepath.Rel(repoPath, currentPath)
 		if bruhErr != nil {
 			continue

--- a/filespane.go
+++ b/filespane.go
@@ -705,6 +705,10 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 				entrySizeText = "?"
 			}
 
+			if entryInfo.Mode()&os.ModeSymlink != 0 {
+				entrySizeText = "-> " + entrySizeText
+			}
+
 			entrySizeText = " " + entrySizeText + " "
 			for j := 0; j < len(entrySizeText); j++ {
 				screen.SetContent(x+w-len(entrySizeText)+j-1, y+i, rune(entrySizeText[j]), nil, style)

--- a/gitstatushandler.go
+++ b/gitstatushandler.go
@@ -226,7 +226,7 @@ func (gsh *GitStatusHandler) Init() {
 				gsh.app.QueueUpdateDraw(func() {})
 
 				changedFiles, err := gogitstatus.StatusWithContext(gsh.ctx, gsh.repoPathCurrentlyWorkingOn)
-				changedFiles = gogitstatus.ChangedFilesIncludingDirectories(changedFiles)
+				changedFiles = gogitstatus.IncludingDirectories(changedFiles)
 
 				if err != nil {
 					gsh.fen.runningGitStatus = false // Can't defer this because it has to run before QueueUpdateDraw()

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/kivattt/getopt v0.0.0-20240907012637-674e0e42e04f
-	github.com/kivattt/gogitstatus v0.0.0-20241102160917-9feffc03ed74
+	github.com/kivattt/gogitstatus v0.0.0-20241107135129-774c1fde4675
 	github.com/otiai10/copy v1.14.0
 	github.com/rivo/tview v0.0.0-20241030223020-e34b54cd4c27
 	github.com/yuin/gluamapper v0.0.0-20150323120927-d836955830e7

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,10 @@ github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uh
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/kivattt/getopt v0.0.0-20240907012637-674e0e42e04f h1:myfMHJX0b7esBOYuclPjnBOclu2uIxe0XDJG0Y7ToGA=
 github.com/kivattt/getopt v0.0.0-20240907012637-674e0e42e04f/go.mod h1:XbVdQu8SHHjoqISPmGcFvHQ8xFuutDrbc4pdw1US62s=
-github.com/kivattt/gogitstatus v0.0.0-20241025103638-d9516b2a89c5 h1:YP6eCig/6jJ6PeAfym5Aq+Fh6ANhUhFNKi6hEvFI04g=
-github.com/kivattt/gogitstatus v0.0.0-20241025103638-d9516b2a89c5/go.mod h1:PnoARDQ/sJtGyx+UYcX2OqHjbA4akv7oj1b3CmncZLs=
-github.com/kivattt/gogitstatus v0.0.0-20241102160917-9feffc03ed74 h1:s5vKuwIPBYXZgkSJSsCVlxzvWxenzLrNugKrS7EHFOQ=
-github.com/kivattt/gogitstatus v0.0.0-20241102160917-9feffc03ed74/go.mod h1:PnoARDQ/sJtGyx+UYcX2OqHjbA4akv7oj1b3CmncZLs=
+github.com/kivattt/gogitstatus v0.0.0-20241107130111-b05c1858b701 h1:FQ0tpGHDqdvgHzUbY1tP3CptBMGarWHdmmI8XZ8YX5A=
+github.com/kivattt/gogitstatus v0.0.0-20241107130111-b05c1858b701/go.mod h1:PnoARDQ/sJtGyx+UYcX2OqHjbA4akv7oj1b3CmncZLs=
+github.com/kivattt/gogitstatus v0.0.0-20241107135129-774c1fde4675 h1:qHH8zRTLAANxZiaObrZgpDTOFoZF2tAvirr7Tp509tQ=
+github.com/kivattt/gogitstatus v0.0.0-20241107135129-774c1fde4675/go.mod h1:PnoARDQ/sJtGyx+UYcX2OqHjbA4akv7oj1b3CmncZLs=
 github.com/kivattt/tcell-naively-faster/v2 v2.0.1 h1:+kTjmvCYTLoEb7evW3UoJM3lMaV+TQKaVzAou2xMoqw=
 github.com/kivattt/tcell-naively-faster/v2 v2.0.1/go.mod h1:2tg6gQmD3C2WJK0NBUrWnjIV6nSjv+j5w/+monQdfVI=
 github.com/kivattt/tview v1.0.4 h1:ZPydRJOzzmopB66x1M3G1v8oiRDcCvtCHFeJPo5VXRo=

--- a/librariesscreen.go
+++ b/librariesscreen.go
@@ -36,7 +36,7 @@ var librariesList = []library{
 	{name: "gluamapper", url: "https://github.com/yuin/gluamapper", version: "commit d836955", license: "MIT", licenseURL: "https://github.com/yuin/gluamapper/blob/master/LICENSE"},
 	{name: "gopher-luar", url: "https://layeh.com/gopher-luar", version: "v1.0.11", license: "MPL 2.0", licenseURL: "https://github.com/layeh/gopher-luar/blob/master/LICENSE"},
 	{name: "rsc/getopt", url: "https://github.com/rsc/getopt", customRevisionURL: "https://github.com/kivattt/getopt", license: "BSD 3-Clause", licenseURL: "https://github.com/rsc/getopt/blob/master/LICENSE"},
-	{name: "kivattt/gogitstatus", url: "https://github.com/kivattt/gogitstatus", version: "commit 9feffc0", license: "MIT", licenseURL: "https://github.com/kivattt/gogitstatus/blob/main/LICENSE"},
+	{name: "kivattt/gogitstatus", url: "https://github.com/kivattt/gogitstatus", version: "commit 774c1fd", license: "MIT", licenseURL: "https://github.com/kivattt/gogitstatus/blob/main/LICENSE"},
 }
 
 func (librariesScreen *LibrariesScreen) Draw(screen tcell.Screen) {

--- a/main.go
+++ b/main.go
@@ -335,7 +335,7 @@ func main() {
 		}
 
 		// Setting the clipboard is disallowed in no-write mode because it runs a shell command
-		if !fen.config.NoWrite && (runtime.GOOS == "linux" || runtime.GOOS == "freebsd") && event.Buttons() == tcell.Button1 {
+		if !fen.config.NoWrite && (runtime.GOOS == "linux" || runtime.GOOS == "freebsd") && (event.Buttons() == tcell.Button1 || event.Buttons() == tcell.Button2) {
 			_, mouseY := event.Position()
 			if mouseY == 0 {
 				err := SetClipboardLinuxXClip(fen.sel)
@@ -381,7 +381,7 @@ func main() {
 
 		// Movement/navigation keys
 		switch event.Buttons() {
-		case tcell.Button1:
+		case tcell.Button1, tcell.Button2:
 			x, y, w, h := fen.middlePane.GetInnerRect()
 			mouseX, mouseY := event.Position()
 

--- a/main.go
+++ b/main.go
@@ -357,8 +357,12 @@ func main() {
 			if mouseY == 0 {
 				if fen.showHomePathAsTilde {
 					fen.showHomePathAsTilde = false
-					if !fen.config.NoWrite && (runtime.GOOS == "linux" || runtime.GOOS == "freebsd") {
-						fen.topBar.additionalText = "Click to copy"
+					if runtime.GOOS == "linux" || runtime.GOOS == "freebsd" {
+						if fen.config.NoWrite {
+							fen.topBar.additionalText = "[red]Copying unavailable (no-write)"
+						} else {
+							fen.topBar.additionalText = "Click to copy"
+						}
 						fen.topBar.showAdditionalText = true
 					}
 					return nil, action
@@ -366,9 +370,7 @@ func main() {
 			} else {
 				if !fen.showHomePathAsTilde {
 					fen.showHomePathAsTilde = true
-					if !fen.config.NoWrite && (runtime.GOOS == "linux" || runtime.GOOS == "freebsd") {
-						fen.topBar.showAdditionalText = false
-					}
+					fen.topBar.showAdditionalText = false
 					return nil, action
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.12"
+const version = "v1.7.13"
 
 func main() {
 	//	f, _ := os.Create("profile.prof")

--- a/main.go
+++ b/main.go
@@ -1015,6 +1015,15 @@ func main() {
 			}
 			return nil
 		} else if event.Modifiers()&tcell.ModCtrl != 0 && event.Key() == tcell.KeyRight { // Ctrl+Right
+			stat, err := os.Lstat(fen.sel)
+			if err == nil && stat.Mode()&os.ModeSymlink != 0 {
+				err := fen.GoSymlink(fen.sel)
+				if err != nil {
+					fen.bottomBar.TemporarilyShowTextInstead(err.Error())
+				}
+				return nil
+			}
+
 			if !fen.config.GitStatus {
 				fen.GoRightUpToHistory()
 				return nil

--- a/main.go
+++ b/main.go
@@ -384,6 +384,7 @@ func main() {
 		// Movement/navigation keys
 		switch event.Buttons() {
 		case tcell.Button1, tcell.Button2:
+			// Small inconsistency with --ui-borders when clicking the left border of the middlepane, not important
 			x, y, w, h := fen.middlePane.GetInnerRect()
 			mouseX, mouseY := event.Position()
 
@@ -1020,14 +1021,17 @@ func main() {
 			}
 
 			path, err := fen.gitStatusHandler.TryFindParentGitRepository(filepath.Dir(fen.sel))
-			if err == nil {
-				err := fen.GoRightUpToFirstUnstagedOrUntracked(path, fen.sel)
-				if err != nil {
-					fen.GoRightUpToHistory()
-				}
-			} else {
+			if err != nil {
 				fen.GoRightUpToHistory()
+				return nil
 			}
+
+			err = fen.GoRightUpToFirstUnstagedOrUntracked(path, fen.sel)
+			if err != nil {
+				fen.GoRightUpToHistory()
+				return nil
+			}
+
 			return nil
 		} else if event.Modifiers()&tcell.ModCtrl != 0 && event.Key() == tcell.KeyLeft { // Ctrl+Left
 			if !fen.config.GitStatus {

--- a/main.go
+++ b/main.go
@@ -280,15 +280,15 @@ func main() {
 		} else if event.Key() == tcell.KeyF1 || event.Rune() == '?' || event.Key() == tcell.KeyEscape || event.Rune() == 'q' {
 			helpScreen.visible = false
 			helpScreen.scrollIndex = 0
-			pages.RemovePage("helpscreen")
+			pages.RemovePage("popup")
 			fen.ShowFilepanes()
 			return nil
 		} else if event.Key() == tcell.KeyF2 {
 			helpScreen.visible = false
 			helpScreen.scrollIndex = 0
-			pages.RemovePage("helpscreen")
+			pages.RemovePage("popup")
 			librariesScreen.visible = true
-			pages.AddPage("librariesscreen", librariesScreen, true, true)
+			pages.AddPage("popup", librariesScreen, true, true)
 			return nil
 		}
 		return event
@@ -297,16 +297,16 @@ func main() {
 	librariesScreen.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() == tcell.KeyF2 || event.Key() == tcell.KeyEscape || event.Rune() == 'q' {
 			librariesScreen.visible = false
-			pages.RemovePage("librariesscreen")
+			pages.RemovePage("popup")
 			fen.ShowFilepanes()
 			return nil
 		}
 
 		if event.Key() == tcell.KeyF1 || event.Rune() == '?' {
 			librariesScreen.visible = false
-			pages.RemovePage("librariesscreen")
+			pages.RemovePage("popup")
 			helpScreen.visible = true
-			pages.AddPage("helpscreen", helpScreen, true, true)
+			pages.AddPage("popup", helpScreen, true, true)
 			return nil
 		}
 		return event
@@ -315,7 +315,7 @@ func main() {
 	lastWheelUpTime := time.Now()
 	lastWheelDownTime := time.Now()
 	app.SetMouseCapture(func(event *tcell.EventMouse, action tview.MouseAction) (*tcell.EventMouse, tview.MouseAction) {
-		if pages.HasPage("deletemodal") || pages.HasPage("inputfield") || pages.HasPage("newfilemodal") || pages.HasPage("searchbox") || pages.HasPage("openwith") || pages.HasPage("shellcommand") || pages.HasPage("forcequitmodal") || pages.HasPage("helpscreen") || pages.HasPage("librariesscreen") || pages.HasPage("gotopath") {
+		if pages.HasPage("popup") {
 			// Since `return nil, action` redraws the screen for some reason,
 			// we have to manually pass through mouse movement events so the screen won't flicker when you move your mouse
 			if action == tview.MouseMove {
@@ -429,7 +429,7 @@ func main() {
 	enterWillSelectAutoCompleteInGotoPath := false
 
 	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		if pages.HasPage("deletemodal") || pages.HasPage("inputfield") || pages.HasPage("newfilemodal") || pages.HasPage("searchbox") || pages.HasPage("openwith") || pages.HasPage("shellcommand") || pages.HasPage("forcequitmodal") || pages.HasPage("helpscreen") || pages.HasPage("librariesscreen") || pages.HasPage("gotopath") {
+		if pages.HasPage("popup") {
 			return event
 		}
 
@@ -466,7 +466,7 @@ func main() {
 				AddButtons([]string{"Force quit", "Cancel"}).
 				SetFocus(1). // Default is "No"
 				SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-					pages.RemovePage("forcequitmodal")
+					pages.RemovePage("popup")
 
 					if buttonIndex != 0 {
 						return
@@ -482,7 +482,7 @@ func main() {
 			modal.SetButtonBackgroundColor(tcell.ColorDefault)
 			modal.SetButtonTextColor(tcell.ColorRed)
 
-			pages.AddPage("forcequitmodal", modal, true, true)
+			pages.AddPage("popup", modal, true, true)
 			app.SetFocus(modal)
 			return nil
 		}
@@ -546,7 +546,7 @@ func main() {
 			})
 
 			inputField.SetDoneFunc(func(key tcell.Key) {
-				pages.RemovePage("searchbox")
+				pages.RemovePage("popup")
 
 				if key == tcell.KeyEscape {
 					return
@@ -572,7 +572,7 @@ func main() {
 			inputField.SetLabelColor(tcell.NewRGBColor(0, 255, 0)) // Green
 			inputField.SetPlaceholderStyle(tcell.StyleDefault.Background(tcell.ColorGray).Dim(true))
 
-			pages.AddPage("searchbox", centered(inputField, 3), true, true)
+			pages.AddPage("popup", centered(inputField, 3), true, true)
 			return nil
 		} else if event.Rune() == 'A' {
 			for _, e := range fen.middlePane.entries.Load().([]os.DirEntry) {
@@ -602,21 +602,21 @@ func main() {
 
 			inputField.SetDoneFunc(func(key tcell.Key) {
 				if key == tcell.KeyEscape {
-					pages.RemovePage("inputfield")
+					pages.RemovePage("popup")
 					return
 				} else if key == tcell.KeyEnter {
 					if !fen.config.NoWrite {
 						newPath := filepath.Join(filepath.Dir(fileToRename), inputField.GetText())
 						_, err := os.Lstat(newPath)
 						if err == nil {
-							pages.RemovePage("inputfield")
+							pages.RemovePage("popup")
 							fen.bottomBar.TemporarilyShowTextInstead("Can't rename to an existing file")
 							return
 						}
 
 						err = os.Rename(fileToRename, newPath)
 						if err != nil {
-							pages.RemovePage("inputfield")
+							pages.RemovePage("popup")
 							fen.bottomBar.TemporarilyShowTextInstead("Can't rename, no access")
 							return
 						}
@@ -634,7 +634,7 @@ func main() {
 						fen.bottomBar.TemporarilyShowTextInstead("Can't rename in no-write mode")
 					}
 
-					pages.RemovePage("inputfield")
+					pages.RemovePage("popup")
 					return
 				}
 			})
@@ -647,7 +647,7 @@ func main() {
 			inputField.SetLabelStyle(tcell.StyleDefault.Background(tcell.ColorBlack)) // This has to be before the .SetLabelColor
 			inputField.SetLabelColor(tcell.NewRGBColor(0, 255, 0))                    // Green
 
-			pages.AddPage("inputfield", centered(inputField, 3), true, true)
+			pages.AddPage("popup", centered(inputField, 3), true, true)
 			app.SetFocus(inputField)
 			return nil
 		} else if event.Rune() == 'n' || event.Rune() == 'N' {
@@ -663,13 +663,13 @@ func main() {
 
 			inputField.SetDoneFunc(func(key tcell.Key) {
 				if key == tcell.KeyEscape {
-					pages.RemovePage("newfilemodal")
+					pages.RemovePage("popup")
 					return
 				} else if key == tcell.KeyEnter {
 					pathToUse := filepath.Join(fen.wd, inputField.GetText())
 					if filepath.Dir(pathToUse) != fen.wd || (runtime.GOOS != "windows" && pathToUse == string(os.PathSeparator)) || strings.ContainsRune(inputField.GetText(), os.PathSeparator) {
 						fen.bottomBar.TemporarilyShowTextInstead("Paths outside of the current folder are not yet supported")
-						pages.RemovePage("newfilemodal")
+						pages.RemovePage("popup")
 						return
 					}
 
@@ -701,7 +701,7 @@ func main() {
 						fen.bottomBar.TemporarilyShowTextInstead("Can't create an existing file")
 					}
 
-					pages.RemovePage("newfilemodal")
+					pages.RemovePage("popup")
 					return
 				}
 			})
@@ -715,7 +715,7 @@ func main() {
 			inputField.SetLabelStyle(tcell.StyleDefault.Background(tcell.ColorBlack)) // This has to be before the .SetLabelColor
 			inputField.SetLabelColor(tcell.NewRGBColor(0, 255, 0))                    // Green
 
-			pages.AddPage("newfilemodal", centered(inputField, 3), true, true)
+			pages.AddPage("popup", centered(inputField, 3), true, true)
 			app.SetFocus(inputField)
 			return nil
 		} else if event.Rune() == 'y' {
@@ -805,20 +805,20 @@ func main() {
 		} else if event.Key() == tcell.KeyF1 || event.Rune() == '?' {
 			helpScreen.visible = !helpScreen.visible
 			if helpScreen.visible {
-				pages.AddPage("helpscreen", helpScreen, true, true)
+				pages.AddPage("popup", helpScreen, true, true)
 				fen.HideFilepanes()
 			} else {
-				pages.RemovePage("helpscreen")
+				pages.RemovePage("popup")
 				fen.ShowFilepanes()
 			}
 			return nil
 		} else if event.Key() == tcell.KeyF2 {
 			librariesScreen.visible = !librariesScreen.visible
 			if librariesScreen.visible {
-				pages.AddPage("librariesscreen", librariesScreen, true, true)
+				pages.AddPage("popup", librariesScreen, true, true)
 				fen.HideFilepanes()
 			} else {
-				pages.RemovePage("librariesscreen")
+				pages.RemovePage("popup")
 				fen.ShowFilepanes()
 			}
 			return nil
@@ -875,7 +875,7 @@ func main() {
 				AddButtons([]string{"Yes", "No"}).
 				SetFocus(1). // Default is "No"
 				SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-					pages.RemovePage("deletemodal")
+					pages.RemovePage("popup")
 
 					if buttonIndex != 0 {
 						return
@@ -908,7 +908,7 @@ func main() {
 			modal.SetButtonBackgroundColor(tcell.ColorDefault)
 			modal.SetButtonTextColor(tcell.ColorRed)
 
-			pages.AddPage("deletemodal", modal, true, true)
+			pages.AddPage("popup", modal, true, true)
 			app.SetFocus(modal)
 			return nil
 		} else if event.Rune() == 'c' {
@@ -919,22 +919,22 @@ func main() {
 
 			inputField.SetDoneFunc(func(key tcell.Key) {
 				if key == tcell.KeyEscape {
-					pages.RemovePage("gotopath")
+					pages.RemovePage("popup")
 					return
 				} else if key == tcell.KeyEnter {
 					if inputField.GetText() == "" {
-						pages.RemovePage("gotopath")
+						pages.RemovePage("popup")
 						return
 					}
 
 					path, err := fen.GoPath(inputField.GetText())
 					if err != nil {
-						pages.RemovePage("gotopath")
+						pages.RemovePage("popup")
 						fen.bottomBar.TemporarilyShowTextInstead(err.Error())
 						return
 					}
 
-					pages.RemovePage("gotopath")
+					pages.RemovePage("popup")
 					fen.bottomBar.TemporarilyShowTextInstead("Moved to path: \"" + path + "\"")
 					return
 				}
@@ -997,7 +997,7 @@ func main() {
 
 			enterWillSelectAutoCompleteInGotoPath = false
 
-			pages.AddPage("gotopath", centered(inputField, 3), true, true)
+			pages.AddPage("popup", centered(inputField, 3), true, true)
 			app.SetFocus(inputField)
 			return nil
 		} else if event.Key() == tcell.KeyF5 {
@@ -1067,7 +1067,7 @@ func main() {
 
 			inputField.SetDoneFunc(func(key tcell.Key) {
 				if key == tcell.KeyEscape {
-					pages.RemovePage("openwith")
+					pages.RemovePage("popup")
 					return
 				}
 
@@ -1077,7 +1077,7 @@ func main() {
 						programNameToUse = programs[0]
 					}
 				}
-				pages.RemovePage("openwith")
+				pages.RemovePage("popup")
 				fen.GoRight(app, programNameToUse)
 			})
 
@@ -1088,7 +1088,7 @@ func main() {
 			flex.SetBorder(true)
 			flex.SetBorderStyle(tcell.StyleDefault.Background(tcell.ColorBlack))
 
-			pages.AddPage("openwith", centered(flex, inputFieldHeight+2+len(programs)), true, true)
+			pages.AddPage("popup", centered(flex, inputFieldHeight+2+len(programs)), true, true)
 			return nil
 		} else if event.Rune() == '!' {
 			shellName := GetShellArgs()[0]
@@ -1108,18 +1108,18 @@ func main() {
 
 			inputField.SetDoneFunc(func(key tcell.Key) {
 				if key == tcell.KeyEscape {
-					pages.RemovePage("shellcommand")
+					pages.RemovePage("popup")
 					return
 				}
 
 				if fen.config.NoWrite {
-					pages.RemovePage("shellcommand")
+					pages.RemovePage("popup")
 					fen.bottomBar.TemporarilyShowTextInstead("Can't run shell commands in no-write mode")
 					return
 				}
 
 				if inputField.GetText() == "" {
-					pages.RemovePage("shellcommand")
+					pages.RemovePage("popup")
 					fen.bottomBar.TemporarilyShowTextInstead("Empty command, nothing done")
 					return
 				}
@@ -1156,10 +1156,10 @@ func main() {
 					fen.bottomBar.TemporarilyShowTextInstead(err.Error())
 				}
 
-				pages.RemovePage("shellcommand")
+				pages.RemovePage("popup")
 			})
 
-			pages.AddPage("shellcommand", centered(inputField, 3), true, true)
+			pages.AddPage("popup", centered(inputField, 3), true, true)
 			return nil
 		} else if event.Rune() == 'b' {
 			err := fen.BulkRename(app)

--- a/util.go
+++ b/util.go
@@ -107,14 +107,13 @@ func EntrySizeText(stat os.FileInfo, path string, hiddenFiles bool) (string, err
 	var ret strings.Builder
 
 	// Show the size of the target, not the symlink
+	// TODO: Use filepath.EvalSymlinks() ?
 	if stat.Mode()&os.ModeSymlink != 0 {
 		var err error
 		stat, err = os.Stat(path)
 		if err != nil {
 			return "", err
 		}
-
-		ret.WriteString("-> ")
 	}
 
 	if !stat.IsDir() {


### PR DESCRIPTION
- Mouse right-click now behaves the same as left-click
- Ctrl+Right can now take you to the target path of symlinks
- On Linux/FreeBSD, hovering over the top bar when `--no-write` is enabled now shows a "Copying unavailable" message
- The "->" text indicating symlinks in file panes no longer disappears when its size is unknown

### `fen.git_status = true` changes:
- Fixed a bug introduced in release v1.7.11 where Ctrl+Right considered folders changed files, making it sometimes not select an unchanged file
- Fixed a bug introduced in release v1.7.11 where sometimes only the parent folder of a changed file would be shown in red

