### PR TITLE
Release v1.7.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Arrow keys, hjkl, mouse click or scrollwheel to navigate (Enter goes right), Esc
 <kbd>?</kbd> or <kbd>F1</kbd> Toggle help menu\
 <kbd>F2</kbd> Show libraries used in fen\
 <kbd>q</kbd> Quit fen\
+<kbd>o</kbd> Options\
 <kbd>z</kbd> or <kbd>Backspace</kbd> Toggle hidden files\
 <kbd>Ctrl + Space</kbd> or <kbd>Ctrl + n</kbd> Open file(s) with specific program\
 <kbd>!</kbd> Run system shell command (cmd on Windows)\

--- a/fen.go
+++ b/fen.go
@@ -621,7 +621,12 @@ func (fen *Fen) GoRight(app *tview.Application, openWith string) {
 	fen.DisableSelectingWithV()
 }
 
-func (fen *Fen) GoUp(numEntries ...int) {
+// Returns false if nothing happened (at the top, would've moved to the same position)
+func (fen *Fen) GoUp(numEntries ...int) bool {
+	if fen.middlePane.selectedEntryIndex <= 0 {
+		return false
+	}
+
 	numEntriesToMove := 1
 	if len(numEntries) > 0 {
 		numEntriesToMove = max(1, numEntries[0])
@@ -635,13 +640,19 @@ func (fen *Fen) GoUp(numEntries ...int) {
 
 	if fen.middlePane.selectedEntryIndex-numEntriesToMove < 0 {
 		fen.sel = filepath.Join(fen.wd, fen.middlePane.GetSelectedEntryFromIndex(0))
-		return
+		return true
 	}
 
 	fen.sel = filepath.Join(fen.wd, fen.middlePane.GetSelectedEntryFromIndex(fen.middlePane.selectedEntryIndex-numEntriesToMove))
+	return true
 }
 
-func (fen *Fen) GoDown(numEntries ...int) {
+// Returns false if nothing happened (at the bottom, would've moved to the same position)
+func (fen *Fen) GoDown(numEntries ...int) bool {
+	if fen.middlePane.selectedEntryIndex >= len(fen.middlePane.entries.Load().([]os.DirEntry))-1 {
+		return false
+	}
+
 	numEntriesToMove := 1
 	if len(numEntries) > 0 {
 		numEntriesToMove = max(1, numEntries[0])
@@ -655,10 +666,11 @@ func (fen *Fen) GoDown(numEntries ...int) {
 
 	if fen.middlePane.selectedEntryIndex+numEntriesToMove >= len(fen.middlePane.entries.Load().([]os.DirEntry)) {
 		fen.sel = filepath.Join(fen.wd, fen.middlePane.GetSelectedEntryFromIndex(len(fen.middlePane.entries.Load().([]os.DirEntry))-1))
-		return
+		return true
 	}
 
 	fen.sel = filepath.Join(fen.wd, fen.middlePane.GetSelectedEntryFromIndex(fen.middlePane.selectedEntryIndex+numEntriesToMove))
+	return true
 }
 
 func (fen *Fen) GoTop() {

--- a/fen.go
+++ b/fen.go
@@ -44,7 +44,8 @@ type Fen struct {
 	helpScreenVisible      *bool
 	librariesScreenVisible *bool
 
-	runningGitStatus bool
+	runningGitStatus     bool
+	initializedGitStatus bool // This is for Fini() because the user might have disabled git_status in the options menu
 
 	topBar     *TopBar
 	bottomBar  *BottomBar
@@ -177,6 +178,7 @@ func (fen *Fen) Init(path string, app *tview.Application, helpScreenVisible *boo
 	if fen.config.GitStatus {
 		fen.gitStatusHandler = GitStatusHandler{app: app, fen: fen}
 		fen.gitStatusHandler.Init()
+		fen.initializedGitStatus = true
 	}
 
 	fen.helpScreenVisible = helpScreenVisible
@@ -245,7 +247,7 @@ func (fen *Fen) Fini() {
 	fen.middlePane.fileWatcher.Close()
 	fen.rightPane.fileWatcher.Close()
 
-	if fen.config.GitStatus {
+	if fen.initializedGitStatus {
 		fen.gitStatusHandler.gitIndexFileWatcher.Close()
 
 		close(fen.gitStatusHandler.channel)

--- a/filespane.go
+++ b/filespane.go
@@ -588,7 +588,11 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 				i++
 			}
 
-			tview.Print(screen, "[::d]Set fen.preview_safety_blocklist = false to disable", x, y+yOffset+i, w, tview.AlignCenter, tcell.ColorRed)
+			text2 := "Set fen.preview_safety_blocklist = false to disable"
+			lines = tview.WordWrap(text2, w)
+			for j, line := range lines {
+				tview.Print(screen, "[::d]"+line, x, y+yOffset+i+j, w, tview.AlignCenter, tcell.ColorRed)
+			}
 			return
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.5
 
 replace github.com/gdamore/tcell/v2 => github.com/kivattt/tcell-naively-faster/v2 v2.0.1
 
-replace github.com/rivo/tview => github.com/kivattt/tview v1.0.4
+replace github.com/rivo/tview => github.com/kivattt/tview v1.0.5
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/kivattt/gogitstatus v0.0.0-20241107135129-774c1fde4675 h1:qHH8zRTLAAN
 github.com/kivattt/gogitstatus v0.0.0-20241107135129-774c1fde4675/go.mod h1:PnoARDQ/sJtGyx+UYcX2OqHjbA4akv7oj1b3CmncZLs=
 github.com/kivattt/tcell-naively-faster/v2 v2.0.1 h1:+kTjmvCYTLoEb7evW3UoJM3lMaV+TQKaVzAou2xMoqw=
 github.com/kivattt/tcell-naively-faster/v2 v2.0.1/go.mod h1:2tg6gQmD3C2WJK0NBUrWnjIV6nSjv+j5w/+monQdfVI=
-github.com/kivattt/tview v1.0.4 h1:ZPydRJOzzmopB66x1M3G1v8oiRDcCvtCHFeJPo5VXRo=
-github.com/kivattt/tview v1.0.4/go.mod h1:02iFIz7K/A9jGCvrizLPvoqr4cEIx7q54RH5Qudkrss=
+github.com/kivattt/tview v1.0.5 h1:85XQYPf4uKhoWysA2bAZFP6wqTxVCz7xxqBoWqyOO1Q=
+github.com/kivattt/tview v1.0.5/go.mod h1:02iFIz7K/A9jGCvrizLPvoqr4cEIx7q54RH5Qudkrss=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/helpscreen.go
+++ b/helpscreen.go
@@ -30,6 +30,7 @@ var helpScreenControlsList = []control{
 	{KeyBindings: []string{"?", "F1"}, Description: "Toggle help menu (you are here!)"},
 	{KeyBindings: []string{"F2"}, Description: "Show libraries used in fen"},
 	{KeyBindings: []string{"q"}, Description: "Quit fen"},
+	{KeyBindings: []string{"o"}, Description: "Options"},
 
 	{KeyBindings: []string{"z", "Backspace"}, Description: "Toggle hidden files"},
 	{KeyBindings: []string{"^Space", "^N"}, Description: "Open file(s) with specific program"},

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.13"
+const version = "v1.7.14"
 
 func main() {
 	//	f, _ := os.Create("profile.prof")

--- a/main.go
+++ b/main.go
@@ -1225,6 +1225,7 @@ func main() {
 
 			optionsAtTheTop := []string{
 				"sort_by",
+				"sort_reverse",
 				"ui_borders",
 			}
 			slices.SortFunc(sortedIndices, func(a, b indexAndText) int {
@@ -1315,12 +1316,20 @@ func main() {
 			})
 
 			optionsForm.SetItemPadding(0)
-			optionsForm.SetTitle("Options")
+			optionsForm.SetTitle("Options this session")
 			optionsForm.SetBorder(true)
 			optionsForm.SetBackgroundColor(tcell.ColorBlack)
 			optionsForm.SetLabelColor(tcell.NewRGBColor(0, 255, 0)) // Green
 			optionsForm.SetBorderPadding(0, 0, 1, 1)
 			optionsForm.SetFieldBackgroundColor(tcell.ColorBlack)
+			optionsForm.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+				if width < 75 {
+					return x + 1, y + 1, width - 2, height - 1
+				}
+				xOffset := width/2 - 21
+				theX := max(x+1, x+xOffset)
+				return theX, y + 1, width - (theX - x) - 1, height - 1
+			})
 
 			pages.AddPage("popup", centered(optionsForm, numOptions+2), true, true)
 			return nil

--- a/main.go
+++ b/main.go
@@ -404,19 +404,31 @@ func main() {
 		case tcell.WheelRight:
 			fen.GoRight(app, "")
 		case tcell.WheelUp:
+			moved := false
 			if time.Since(lastWheelUpTime) > time.Duration(30*time.Millisecond) {
-				fen.GoUp()
+				moved = fen.GoUp()
 			} else {
-				fen.GoUp(fen.config.ScrollSpeed)
+				moved = fen.GoUp(fen.config.ScrollSpeed)
 			}
+
 			lastWheelUpTime = time.Now()
-		case tcell.WheelDown:
-			if time.Since(lastWheelDownTime) > time.Duration(30*time.Millisecond) {
-				fen.GoDown()
-			} else {
-				fen.GoDown(fen.config.ScrollSpeed)
+			if !moved {
+				app.DontDrawOnThisEventMouse()
+				return nil, action
 			}
+		case tcell.WheelDown:
+			moved := false
+			if time.Since(lastWheelDownTime) > time.Duration(30*time.Millisecond) {
+				moved = fen.GoDown()
+			} else {
+				moved = fen.GoDown(fen.config.ScrollSpeed)
+			}
+
 			lastWheelDownTime = time.Now()
+			if !moved {
+				app.DontDrawOnThisEventMouse()
+				return nil, action
+			}
 		default:
 			return nil, action
 		}
@@ -497,9 +509,15 @@ func main() {
 		} else if (event.Modifiers()&tcell.ModCtrl == 0 && event.Key() == tcell.KeyRight) || event.Rune() == 'l' || event.Key() == tcell.KeyEnter {
 			fen.GoRight(app, "")
 		} else if event.Key() == tcell.KeyUp || event.Rune() == 'k' {
-			fen.GoUp()
+			if !fen.GoUp() {
+				app.DontDrawOnThisEventKey()
+				return nil
+			}
 		} else if event.Key() == tcell.KeyDown || event.Rune() == 'j' {
-			fen.GoDown()
+			if !fen.GoDown() {
+				app.DontDrawOnThisEventKey()
+				return nil
+			}
 		} else if event.Rune() == ' ' {
 			fen.ToggleSelection(fen.sel)
 			fen.GoDown()
@@ -1186,6 +1204,7 @@ func main() {
 			return nil
 		}
 
+		app.DontDrawOnThisEventKey()
 		return event
 	})
 

--- a/main.go
+++ b/main.go
@@ -1326,7 +1326,7 @@ func main() {
 				if width < 75 {
 					return x + 1, y + 1, width - 2, height - 1
 				}
-				xOffset := width/2 - 21
+				xOffset := width/2 - 20
 				theX := max(x+1, x+xOffset)
 				return theX, y + 1, width - (theX - x) - 1, height - 1
 			})


### PR DESCRIPTION
- Added an options menu, open with the <kbd>o</kbd> key
- No longer unnecessarily updates the screen when scrolling up/down when already at the top/bottom of the screen respectively
- The red text in the file preview default blocklist is now word-wrapped
- `go.mod.lua` file preview script: Directives are colored orange, now colors all directives