### PR TITLE
Release v1.7.16

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,6 @@
 - Fix a crash (fen hanging) on something like `/proc/.../oom_score_adj`
 - Fix the bottom bar sometimes not showing info on files inside `/proc/.../map_files`
 - Replace github.com/otiai10/copy with my own recursive folder copying
-- Cache folder size (file count)
 - Warning message or enable hidden files when creating a new hidden file/folder
 - Allow creating new files/folders with absolute paths (use fen.GoPath())
 - A sort of "back arrow" key for going to the last folder we were in

--- a/filespane.go
+++ b/filespane.go
@@ -381,12 +381,12 @@ func (fp *FilesPane) FilterAndSortEntries() {
 			// If folder, we consider the folder file count as bytes (though it's kind of messed up with symlinks...)
 			aSize := int(aInfo.Size())
 			if a.IsDir() {
-				aSize, _ = FolderFileCount(filepath.Join(fp.folder, a.Name()), fp.fen.config.HiddenFiles)
+				aSize, _ = FolderFileCountCached(fp.fen.folderFileCountCache, filepath.Join(fp.folder, a.Name()), fp.fen.config.HiddenFiles)
 			}
 
 			bSize := int(bInfo.Size())
 			if b.IsDir() {
-				bSize, _ = FolderFileCount(filepath.Join(fp.folder, b.Name()), fp.fen.config.HiddenFiles)
+				bSize, _ = FolderFileCountCached(fp.fen.folderFileCountCache, filepath.Join(fp.folder, b.Name()), fp.fen.config.HiddenFiles)
 			}
 
 			if aSize < bSize {
@@ -706,7 +706,7 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 
 		entrySizePrintedSize := 0
 		if fp.showEntrySizes {
-			entrySizeText, err := EntrySizeText(entryInfo, entryFullPath, fp.fen.config.HiddenFiles)
+			entrySizeText, err := EntrySizeText(fp.fen.folderFileCountCache, entryInfo, entryFullPath, fp.fen.config.HiddenFiles)
 			if err != nil {
 				entrySizeText = "?"
 			}

--- a/lua-file-preview-examples/markdown.lua
+++ b/lua-file-preview-examples/markdown.lua
@@ -178,7 +178,7 @@ for line in io.lines(fen.SelectedFile) do
 				goto continue
 			end
 
-			if not backtickString and lastChar ~= '\\' then
+			if not backtickString and lastChar ~= '\\' and not isList(lineTrimLeftSpaces:sub(1,1)) then
 				if isEmphasis(lastChar) and isEmphasis(char) then
 					bold = not bold
 					italic = false
@@ -241,11 +241,24 @@ for line in io.lines(fen.SelectedFile) do
 	if lineIsThematicBreak(line) then
 		printThematicBreak(y)
 	elseif isList(lineTrimLeftSpaces:sub(1,1)) then
+		local listXPos = 0
+		for i = 1, #line do
+			local c = line:sub(i,i)
+			if c == ' ' then
+				listXPos = listXPos + 1
+			elseif c == '\t' then
+				listXPos = listXPos + 4
+			end
+			if c ~= ' ' and c ~= '\t' then
+				break
+			end
+		end
+
 		-- The non-graphical FreeBSD console would print a '?' instead of the fancy character, so fallback to an asterix
 		if fen:RuntimeOS() == "freebsd" then
-			fen:PrintSimple("[::d]*", 0, y)
+			fen:PrintSimple("[::d]*", listXPos, y)
 		else
-			fen:PrintSimple("[::d]●", 0, y)
+			fen:PrintSimple("[::d]●", listXPos, y)
 		end
 	end
 

--- a/main.go
+++ b/main.go
@@ -631,6 +631,12 @@ func main() {
 					return
 				} else if key == tcell.KeyEnter {
 					if !fen.config.NoWrite {
+						if inputField.GetText() == "" {
+							pages.RemovePage("popup")
+							fen.bottomBar.TemporarilyShowTextInstead("Can't rename with an empty name")
+							return
+						}
+
 						newPath := filepath.Join(filepath.Dir(fileToRename), inputField.GetText())
 						_, err := os.Lstat(newPath)
 						if err == nil {

--- a/main.go
+++ b/main.go
@@ -773,6 +773,7 @@ func main() {
 			return nil
 		} else if event.Rune() == 'z' || event.Key() == tcell.KeyBackspace {
 			fen.config.HiddenFiles = !fen.config.HiddenFiles
+			fen.InvalidateFolderFileCountCache()
 			fen.DisableSelectingWithV() // FIXME: We shouldn't disable it, but fixing it to not be buggy would be annoying
 			fen.UpdatePanes(true)
 			fen.history.AddToHistory(fen.sel)

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.15"
+const version = "v1.7.16"
 
 func main() {
 	//	f, _ := os.Create("profile.prof")


### PR DESCRIPTION
- Folder file counts are now cached, improving performance
- Added a "Can't rename with an empty name" error message
- `markdown.lua` file preview script: Fixed the position of list characters when there's preceding whitespace