### PR TITLE
Release v1.7.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ You can find examples in [lua-file-open-examples](lua-file-open-examples)
 - fen may crash in the middle of deleting files due to a data race, most commonly when deleting a lot of files (like 4000)
 - File previews are ran synchronously, which means they slow down fen
 - fen intentionally does not handle Unicode "grapheme clusters" (like chinese text) in filenames correctly for performance reasons. You need to manually build fen with the replace directive for my [tcell fork](https://github.com/kivattt/tcell-naively-faster) in the go.mod file removed to show them correctly
-- Symlinks have no special distinction, a folder symlink will appear like a normal folder
 - On FreeBSD, when the disk is full, fen may erroneously show a very large amount of disk space available (like `18.446 EB free`), when in reality there is no available space
 - `go test` doesn't work on Windows
 - The color for audio files is invisible in the default Windows Powershell colors, but not cmd or Windows Terminal

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@
 - topbar.go: Show left part of path also with invisible unicode symbols as codepoints highlighted, and also show symlinks in blue like ranger
 - Configurable filespane proportions
 - Warn when deleting hidden files while hidden files aren't visible
+- Scrollable file previews (fen handles absolute scroll position, hands it to lua as a var)
 
 - Abstract away this common pattern:
 ```go

--- a/config.lua
+++ b/config.lua
@@ -17,6 +17,7 @@ fen.scroll_speed = 2 -- When scrolling faster than 30ms per scroll, scroll this 
 fen.git_status = false -- EXPERIMENTAL: When true, unstaged/untracked files in local git repositories are shown in red
 fen.preview_safety_blocklist = true -- Prevents common sensitive file types from being previewed
 fen.close_on_escape = false -- Use the Escape key to close fen, useful for embedding in other applications
+fen.file_size_in_all_panes = true
 
 -- Everything below this line is non-default examples
 

--- a/fen.go
+++ b/fen.go
@@ -93,6 +93,7 @@ type Config struct {
 	GitStatus               bool                 `lua:"git_status"`
 	PreviewSafetyBlocklist  bool                 `lua:"preview_safety_blocklist"`
 	CloseOnEscape           bool                 `lua:"close_on_escape"`
+	FileSizeInAllPanes      bool                 `lua:"file_size_in_all_panes"`
 }
 
 func NewConfigDefaultValues() Config {
@@ -177,6 +178,14 @@ type PreviewOrOpenEntry struct {
 	DoNotMatch []string
 }
 
+type PanePos int
+
+const (
+	LeftPane PanePos = iota
+	MiddlePane
+	RightPane
+)
+
 func (fen *Fen) Init(path string, app *tview.Application, helpScreenVisible *bool, librariesScreenVisible *bool) error {
 	fen.app = app
 	fen.fileOperationsHandler = FileOperationsHandler{fen: fen}
@@ -205,9 +214,9 @@ func (fen *Fen) Init(path string, app *tview.Application, helpScreenVisible *boo
 
 	fen.topBar = NewTopBar(fen)
 
-	fen.leftPane = NewFilesPane(fen, false, false)
-	fen.middlePane = NewFilesPane(fen, true, false)
-	fen.rightPane = NewFilesPane(fen, false, true)
+	fen.leftPane = NewFilesPane(fen, LeftPane)
+	fen.middlePane = NewFilesPane(fen, MiddlePane)
+	fen.rightPane = NewFilesPane(fen, RightPane)
 
 	fen.leftPane.Init()
 	fen.middlePane.Init()

--- a/fen.go
+++ b/fen.go
@@ -1050,8 +1050,9 @@ func (fen *Fen) GoRightUpToHistory() {
 	fen.GoPath(path)
 }
 
-// Goes to a random unstaged/untracked file from the currently selected folder
-// It will select the shortest filepath, if there are filepaths of equal length they will be chosen at random
+// This goes to the changed file (any non-folder) closest to the root path of repoPath.
+// If there are multiple candidates, it will select the one with the shortest filepath.
+// If there are some filepaths of equal length, it will choose one randomly.
 // TODO: Implement sorting function in gogitstatus so this is deterministic
 func (fen *Fen) GoRightUpToFirstUnstagedOrUntracked(repoPath, currentPath string) error {
 	fen.gitStatusHandler.trackedLocalGitReposMutex.Lock()
@@ -1063,6 +1064,7 @@ func (fen *Fen) GoRightUpToFirstUnstagedOrUntracked(repoPath, currentPath string
 	}
 
 	changedFileClosestToRoot := ""
+	shortestPathSeparatorCount := 0
 	for changedFilePath := range gogitstatus.ExcludingDirectories(repo.changedFiles) {
 		bruhRel, bruhErr := filepath.Rel(repoPath, currentPath)
 		if bruhErr != nil {
@@ -1078,8 +1080,10 @@ func (fen *Fen) GoRightUpToFirstUnstagedOrUntracked(repoPath, currentPath string
 			continue
 		}
 
-		if changedFileClosestToRoot == "" || len(rel) < len(changedFileClosestToRoot) {
+		pathSeparatorCount := strings.Count(rel, string(os.PathSeparator))
+		if changedFileClosestToRoot == "" || pathSeparatorCount < shortestPathSeparatorCount || (pathSeparatorCount == shortestPathSeparatorCount && len(rel) < len(changedFileClosestToRoot)) {
 			changedFileClosestToRoot = rel
+			shortestPathSeparatorCount = pathSeparatorCount
 		}
 	}
 

--- a/filespane.go
+++ b/filespane.go
@@ -30,8 +30,7 @@ type FilesPane struct {
 	folder              string       // Can be a path to a file
 	entries             atomic.Value // []os.DirEntry
 	selectedEntryIndex  int
-	showEntrySizes      bool
-	isRightFilesPane    bool
+	panePos             PanePos
 	parentIsEmptyFolder bool
 	Invisible           bool
 	fileWatcher         *fsnotify.Watcher
@@ -43,14 +42,13 @@ type FilesPane struct {
 	lastRenamedPathTime time.Time
 }
 
-func NewFilesPane(fen *Fen, showEntrySizes, isRightFilesPane bool) *FilesPane {
+func NewFilesPane(fen *Fen, panePos PanePos) *FilesPane {
 	newWatcher, _ := fsnotify.NewWatcher()
 	return &FilesPane{
 		Box:                tview.NewBox().SetBackgroundColor(tcell.ColorDefault),
 		fen:                fen,
 		selectedEntryIndex: 0,
-		showEntrySizes:     showEntrySizes,
-		isRightFilesPane:   isRightFilesPane,
+		panePos:            panePos,
 		fileWatcher:        newWatcher,
 	}
 }
@@ -561,18 +559,18 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 		}
 	}
 
-	if fp.isRightFilesPane || fp.fen.config.UiBorders {
+	if fp.panePos == RightPane || fp.fen.config.UiBorders {
 		w++
 	}
 
-	if fp.isRightFilesPane && fp.parentIsEmptyFolder || (!fp.isRightFilesPane && len(fp.entries.Load().([]os.DirEntry)) <= 0) && fp.folder != filepath.Dir(fp.folder) {
+	if fp.panePos == RightPane && fp.parentIsEmptyFolder || ((fp.panePos != RightPane) && len(fp.entries.Load().([]os.DirEntry)) <= 0) && fp.folder != filepath.Dir(fp.folder) {
 		tview.Print(screen, "[:red]empty", x, y, w, tview.AlignLeft, tcell.ColorDefault)
 		return
 	}
 
 	// File previews
 	stat, statErr := os.Stat(fp.fen.sel)
-	if fp.isRightFilesPane && len(fp.fen.config.Preview) > 0 && statErr == nil && stat.Mode().IsRegular() && fp.CanOpenFile(fp.fen.sel) && len(fp.entries.Load().([]os.DirEntry)) <= 0 {
+	if fp.panePos == RightPane && len(fp.fen.config.Preview) > 0 && statErr == nil && stat.Mode().IsRegular() && fp.CanOpenFile(fp.fen.sel) && len(fp.entries.Load().([]os.DirEntry)) <= 0 {
 		w--
 
 		filenameResolved, err := filepath.EvalSymlinks(fp.fen.sel)
@@ -705,7 +703,7 @@ func (fp *FilesPane) Draw(screen tcell.Screen) {
 		//styleStr := StyleToStyleTagString(style)
 
 		entrySizePrintedSize := 0
-		if fp.showEntrySizes {
+		if fp.fen.config.FileSizeInAllPanes || fp.panePos == MiddlePane {
 			entrySizeText, err := EntrySizeText(fp.fen.folderFileCountCache, entryInfo, entryFullPath, fp.fen.config.HiddenFiles)
 			if err != nil {
 				entrySizeText = "?"

--- a/filespane.go
+++ b/filespane.go
@@ -149,6 +149,13 @@ func AddEventToBatch(oldEvents []fsnotify.Event, newEvent fsnotify.Event) []fsno
 }
 
 func (fp *FilesPane) HandleFileEvent(event fsnotify.Event) error {
+	// Poorly documented fsnotify behaviour, it can send "no events" when watched directories are removed.
+	// This is documented to happen on Windows, but it also happens on Linux.
+	// See: https://github.com/fsnotify/fsnotify/issues/655
+	if event.Op == 0 {
+		return errors.New("No events")
+	}
+
 	if event.Has(fsnotify.Create) {
 		// A file temporarily renamed, then renamed back to its old path within 200 milliseconds is added back to the history.
 		// This is a hack to fix navigation because when vim saves a file it temporarily renames the file by appending a tilde (~),

--- a/main.go
+++ b/main.go
@@ -1337,6 +1337,7 @@ func main() {
 
 			optionsForm.SetItemPadding(0)
 			optionsForm.SetTitle("Options this session")
+			optionsForm.SetTitleColor(tcell.ColorDefault)
 			optionsForm.SetBorder(true)
 			optionsForm.SetBackgroundColor(tcell.ColorBlack)
 			optionsForm.SetLabelColor(tcell.NewRGBColor(0, 255, 0)) // Green

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.18"
+const version = "v1.7.19"
 
 func main() {
 	//	f, _ := os.Create("profile.prof")
@@ -1235,6 +1235,7 @@ func main() {
 			}
 
 			optionsAtTheTop := []string{
+				"git_status",
 				"sort_by",
 				"sort_reverse",
 				"ui_borders",

--- a/main.go
+++ b/main.go
@@ -1037,6 +1037,7 @@ func main() {
 			app.SetFocus(inputField)
 			return nil
 		} else if event.Key() == tcell.KeyF5 {
+			fen.InvalidateFolderFileCountCache()
 			fen.UpdatePanes(true)
 			app.Sync()
 			fen.TriggerGitStatus()
@@ -1211,6 +1212,7 @@ func main() {
 			return nil
 		} else if event.Rune() == 'b' {
 			err := fen.BulkRename(app)
+			defer fen.UpdatePanes(false)
 			if err != nil {
 				fen.bottomBar.TemporarilyShowTextInstead(err.Error())
 				return nil
@@ -1282,6 +1284,12 @@ func main() {
 							app.EnableMouse(checked)
 							fen.UpdatePanes(true)
 						}
+					} else if fieldName == "hidden_files" {
+						f = func(checked bool) {
+							*fieldPtr.(*bool) = checked
+							fen.InvalidateFolderFileCountCache()
+							fen.UpdatePanes(true)
+						}
 					} else if fieldName == "git_status" {
 						// Don't show the git_status option if it was disabled on startup, to prevent crashes
 						if !fen.initializedGitStatus {
@@ -1335,7 +1343,7 @@ func main() {
 			optionsForm.SetBorderPadding(0, 0, 1, 1)
 			optionsForm.SetFieldBackgroundColor(tcell.ColorBlack)
 			optionsForm.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
-				if width < 75 {
+				if width < 80 {
 					return x + 1, y + 1, width - 2, height - 1
 				}
 				xOffset := width/2 - 20

--- a/util_test.go
+++ b/util_test.go
@@ -67,6 +67,25 @@ func TestStyleToStyleTagString(t *testing.T) {
 	}
 }
 
+func TestRuneToPrintableCode(t *testing.T) {
+	expectedResults := map[rune]string{
+		'a': "\\u61",
+		'z': "\\u7a",
+		' ': "\\u20",
+		'🥺': "\\u1f97a",
+		'\a': "\\a",
+		'\v': "\\v",
+		'\t': "\\t",
+	}
+
+	for input, expected := range expectedResults {
+		got := RuneToPrintableCode(input)
+		if got != expected {
+			t.Fatal("Expected " + expected + ", but got " + got)
+		}
+	}
+}
+
 func TestFilenameInvisibleCharactersAsCodeHighlighted(t *testing.T) {
 	expectedResults := map[[2]string]string{
 		{"file.txt", ""}:            "file.txt",

--- a/util_test.go
+++ b/util_test.go
@@ -69,10 +69,10 @@ func TestStyleToStyleTagString(t *testing.T) {
 
 func TestRuneToPrintableCode(t *testing.T) {
 	expectedResults := map[rune]string{
-		'a': "\\u61",
-		'z': "\\u7a",
-		' ': "\\u20",
-		'🥺': "\\u1f97a",
+		'a':  "\\u61",
+		'z':  "\\u7a",
+		' ':  "\\u20",
+		'🥺':  "\\u1f97a",
 		'\a': "\\a",
 		'\v': "\\v",
 		'\t': "\\t",


### PR DESCRIPTION
- Added option `fen.file_size_in_all_panes` to show file sizes in all panes, not just the middle
- Fixed a bug where toggling `fen.hidden_files` in the options menu would not update folder sizes
- Fixed a bug where fen would crash after a while when left in an unmounted/deleted directory (see: https://github.com/fsnotify/fsnotify/issues/655)
- `Ctrl+Right` in Git repositories now correctly goes to the first changed non-folder closest to the root of the repository, instead of just selecting the shortest filepath
- Put `fen.git_status` at the top of the options menu
- Lowered the brightness of the "Options this session" title for the options menu, and made the left/center alignment change later