### PR TITLE
Release v1.7.23

### DIFF
--- a/fen.go
+++ b/fen.go
@@ -77,9 +77,10 @@ const (
 	SORT_MODIFIED       = "modified"
 	SORT_SIZE           = "size"
 	SORT_FILE_EXTENSION = "file-extension"
+	SORT_NUMBER         = "number"
 )
 
-var ValidSortByValues = [...]string{SORT_NONE, SORT_ALPHABETICAL, SORT_MODIFIED, SORT_SIZE, SORT_FILE_EXTENSION}
+var ValidSortByValues = [...]string{SORT_NONE, SORT_ALPHABETICAL, SORT_NUMBER, SORT_MODIFIED, SORT_SIZE, SORT_FILE_EXTENSION}
 
 const (
 	HUMAN_READABLE = "human-readable"

--- a/filespane.go
+++ b/filespane.go
@@ -418,6 +418,17 @@ func (fp *FilesPane) FilterAndSortEntries() {
 
 			return 1
 		})
+	case SORT_NUMBER:
+		slices.SortStableFunc(fp.entries.Load().([]os.DirEntry), func(a, b fs.DirEntry) int {
+			numberPrefix1 := NumberPrefix(a.Name())
+			numberPrefix2 := NumberPrefix(b.Name())
+
+			if numberPrefix1 == "" || numberPrefix2 == "" {
+				return 0
+			}
+
+			return CompareNumericalStrings(numberPrefix1, numberPrefix2)
+		})
 	case SORT_NONE: // Does nothing, this has the side effect of making file events always show up at the bottom, until the entire folder is re-read
 	default:
 		panic("Invalid sort_by value \"" + fp.fen.config.SortBy + "\"")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-const version = "v1.7.22"
+const version = "v1.7.23"
 
 func SetTviewStyles() {
 	tview.Styles.PrimitiveBackgroundColor = tcell.ColorDefault

--- a/util.go
+++ b/util.go
@@ -1175,3 +1175,76 @@ func splitPathTestable(path string, pathSeparator rune) []string {
 
 	return ret
 }
+
+// Panics on empty string!
+// Returns the number prefix of a string
+// e.g. "123hello" -> "123"
+// and  "hello" -> ""
+func NumberPrefix(s string) string {
+	if len(s) == 0 {
+		panic("NumberPrefix() was passed an empty string")
+	}
+
+	count := 0
+	for _, char := range s {
+		if char < '0' || char > '9' {
+			break
+		}
+
+		count++
+	}
+
+	return s[:count]
+}
+
+// Compares two positive numerical strings.
+// Returns  0 if num1 == num2
+// Returns  1 if num1 > num2
+// Returns -1 if num1 < num2
+func CompareNumericalStrings(num1, num2 string) int {
+	num1Strip := strings.TrimLeft(num1, "0")
+	num2Strip := strings.TrimLeft(num2, "0")
+	len1 := len(num1Strip)
+	len2 := len(num2Strip)
+
+	if len1 > len2 {
+		return 1
+	}
+
+	if len1 < len2 {
+		return -1
+	}
+
+	for i := 0; i < len1; i++ {
+		if num1Strip[i] > num2Strip[i] {
+			return 1
+		} else if num1Strip[i] < num2Strip[i] {
+			return -1
+		}
+	}
+
+	return 0 // Both numbers are equal
+}
+
+// Does tilde expansion on non-windows operating systems
+// If it can't find the home directory, it will return the input unchanged.
+func ExpandTilde(path string) string {
+	if runtime.GOOS == "windows" {
+		return path
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+
+	return expandTildeTestable(path, home)
+}
+
+func expandTildeTestable(path string, homeDir string) string {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		return filepath.Join(homeDir, path[1:])
+	}
+
+	return path
+}


### PR DESCRIPTION
- New `fen.sort_by` option `"number"`, sorts by (positive) number prefix in filenames
- The `Goto path` and `Open with` menus now accept tilde `~` expansion on non-windows operating systems
- The `o` key now toggles the option menu instead of only opening it